### PR TITLE
iterable_go -> github.com/block/iterable-go

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"net/http"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
 )
 
 const (

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"testing"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/campaigns.go
+++ b/api/campaigns.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"iterable-go/logger"
-	"iterable-go/types"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 var (

--- a/api/campaigns_test.go
+++ b/api/campaigns_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"strings"
 
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 var (

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/channels.go
+++ b/api/channels.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 var (

--- a/api/channels_test.go
+++ b/api/channels_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/events.go
+++ b/api/events.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"strings"
 
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 var (

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/api/lists.go
+++ b/api/lists.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 var (

--- a/api/lists_test.go
+++ b/api/lists_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/api/message_types.go
+++ b/api/message_types.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 const pathMessageTypes = "messageTypes"

--- a/api/message_types_test.go
+++ b/api/message_types_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/users.go
+++ b/api/users.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"strings"
 
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 const (

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"encoding/json"
-	"iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
 	"net/http"
 	"testing"
+
+	"github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/batch.go
+++ b/batch.go
@@ -1,7 +1,7 @@
 package iterable_go
 
 import (
-	"iterable-go/batch"
+	"github.com/block/iterable-go/batch"
 )
 
 type Batch struct {

--- a/batch/event_track.go
+++ b/batch/event_track.go
@@ -3,11 +3,11 @@ package batch
 import (
 	"strings"
 
-	"iterable-go/logger"
+	"github.com/block/iterable-go/logger"
 
-	"iterable-go/api"
-	iterable_errors "iterable-go/errors"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/types"
 )
 
 const (

--- a/batch/event_track_test.go
+++ b/batch/event_track_test.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"iterable-go/api"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/batch/list_subscribe.go
+++ b/batch/list_subscribe.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"time"
 
-	"iterable-go/api"
-	iterable_errors "iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/retry"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
+	"github.com/block/iterable-go/types"
 )
 
 var (

--- a/batch/list_subscribe_test.go
+++ b/batch/list_subscribe_test.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"iterable-go/api"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/batch/list_unsubscribe.go
+++ b/batch/list_unsubscribe.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"time"
 
-	"iterable-go/api"
-	iterable_errors "iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/retry"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
+	"github.com/block/iterable-go/types"
 )
 
 type listUnSubscribeBatch struct {

--- a/batch/list_unsubscribe_test.go
+++ b/batch/list_unsubscribe_test.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"iterable-go/api"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/batch/processor.go
+++ b/batch/processor.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"iterable-go/logger"
-	"iterable-go/retry"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
 )
 
 // Processor provides a batching mechanism for processing messages efficiently.

--- a/batch/processor_config.go
+++ b/batch/processor_config.go
@@ -3,8 +3,8 @@ package batch
 import (
 	"time"
 
-	"iterable-go/logger"
-	"iterable-go/retry"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
 )
 
 type ProcessorConfig struct {

--- a/batch/processor_test.go
+++ b/batch/processor_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"iterable-go/logger"
-	"iterable-go/retry"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/batch/subscription_update.go
+++ b/batch/subscription_update.go
@@ -1,9 +1,9 @@
 package batch
 
 import (
-	"iterable-go/api"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 type subscriptionUpdateBatch struct {

--- a/batch/subscription_update_test.go
+++ b/batch/subscription_update_test.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"iterable-go/api"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/batch/testing.go
+++ b/batch/testing.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	iterable_errors "iterable-go/errors"
-	"iterable-go/types"
+	iterable_errors "github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/types"
 )
 
 const (

--- a/batch/user_email_update.go
+++ b/batch/user_email_update.go
@@ -3,9 +3,9 @@ package batch
 import (
 	"fmt"
 
-	"iterable-go/api"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 type userEmailUpdateBatch struct {

--- a/batch/user_update.go
+++ b/batch/user_update.go
@@ -1,10 +1,10 @@
 package batch
 
 import (
-	"iterable-go/api"
-	iterable_errors "iterable-go/errors"
-	"iterable-go/logger"
-	"iterable-go/types"
+	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/types"
 )
 
 type userUpdateBatch struct {

--- a/batch/utils.go
+++ b/batch/utils.go
@@ -3,7 +3,7 @@ package batch
 import (
 	"errors"
 
-	iterable_errors "iterable-go/errors"
+	iterable_errors "github.com/block/iterable-go/errors"
 )
 
 const (

--- a/batch_config.go
+++ b/batch_config.go
@@ -3,9 +3,9 @@ package iterable_go
 import (
 	"time"
 
-	"iterable-go/batch"
-	"iterable-go/logger"
-	"iterable-go/retry"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
 )
 
 type batchConfig struct {

--- a/batch_test.go
+++ b/batch_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"iterable-go/batch"
-	"iterable-go/logger"
-	"iterable-go/retry"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/retry"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/client.go
+++ b/client.go
@@ -3,7 +3,7 @@ package iterable_go
 import (
 	"net/http"
 
-	"iterable-go/api"
+	"github.com/block/iterable-go/api"
 )
 
 type Client struct {

--- a/client_config.go
+++ b/client_config.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"iterable-go/logger"
+	"github.com/block/iterable-go/logger"
 )
 
 type config struct {

--- a/examples/api_campaigns_create.go
+++ b/examples/api_campaigns_create.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/types"
+	"github.com/block/iterable-go"
+	"github.com/block/iterable-go/types"
 )
 
 func api_campaigns_create(apiKey string) {

--- a/examples/api_campaigns_get_all.go
+++ b/examples/api_campaigns_get_all.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_campaigns_get_all(apiKey string) {

--- a/examples/api_catalog_get_all.go
+++ b/examples/api_catalog_get_all.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_catalog_get_all(apiKey string) {

--- a/examples/api_channels_get_all.go
+++ b/examples/api_channels_get_all.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_channels_get_all(apiKey string) {

--- a/examples/api_events_get_by_email.go
+++ b/examples/api_events_get_by_email.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_events_get_by_email(apiKey string) {

--- a/examples/api_events_track.go
+++ b/examples/api_events_track.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/types"
 )
 
 func api_events_track(apiKey string) {

--- a/examples/api_lists_get_all.go
+++ b/examples/api_lists_get_all.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_lists_get_all(apiKey string) {

--- a/examples/api_lists_subscribe.go
+++ b/examples/api_lists_subscribe.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/types"
 )
 
 func api_lists_subscribe(apiKey string) {

--- a/examples/api_message_types_get.go
+++ b/examples/api_message_types_get.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_message_types_get(apiKey string) {

--- a/examples/api_users_bulk_update.go
+++ b/examples/api_users_bulk_update.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/types"
 )
 
 func api_users_bulk_update(apiKey string) {

--- a/examples/api_users_get_by_email.go
+++ b/examples/api_users_get_by_email.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
+	iterable_go "github.com/block/iterable-go"
 )
 
 func api_users_get_by_email(apiKey string) {

--- a/examples/api_users_update_or_create.go
+++ b/examples/api_users_update_or_create.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	iterable_go "iterable-go"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/types"
 )
 
 func api_users_update_or_create(apiKey string) {

--- a/examples/batch_custom_config.go
+++ b/examples/batch_custom_config.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_custom_config(apiKey string) {

--- a/examples/batch_email_update.go
+++ b/examples/batch_email_update.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_email_update(apiKey string) {

--- a/examples/batch_event_track.go
+++ b/examples/batch_event_track.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_event_track(apiKey string) {

--- a/examples/batch_list_subscribe.go
+++ b/examples/batch_list_subscribe.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_list_subscribe(apiKey string) {

--- a/examples/batch_list_unsubscribe.go
+++ b/examples/batch_list_unsubscribe.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_list_unsubscribe(apiKey string) {

--- a/examples/batch_start_stop_all.go
+++ b/examples/batch_start_stop_all.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_start_stop_all(apiKey string) {

--- a/examples/batch_subscription_update.go
+++ b/examples/batch_subscription_update.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_subscription_update(apiKey string) {

--- a/examples/batch_user_update.go
+++ b/examples/batch_user_update.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/types"
 )
 
 func batch_user_update(apiKey string) {

--- a/examples/logger_custom.go
+++ b/examples/logger_custom.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/logger"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/logger"
 )
 
 func logger_custom(apiKey string) {

--- a/examples/retry_custom.go
+++ b/examples/retry_custom.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	iterable_go "iterable-go"
-	"iterable-go/batch"
-	"iterable-go/retry"
-	"iterable-go/types"
+	iterable_go "github.com/block/iterable-go"
+	"github.com/block/iterable-go/batch"
+	"github.com/block/iterable-go/retry"
+	"github.com/block/iterable-go/types"
 )
 
 func retry_custom(apiKey string) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module iterable-go
+module github.com/block/iterable-go
 
 go 1.24.5
 

--- a/retry/expo_retry.go
+++ b/retry/expo_retry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"iterable-go/logger"
+	"github.com/block/iterable-go/logger"
 )
 
 type expoConfig struct {


### PR DESCRIPTION
### Notes

Originally, the project lived in a monorepo. The team used `iterable_go` as a module name.

This doesn't really work for public projects, because it breaks the `go get` command.

```
go get github.com/block/iterable-go@latest 

go: github.com/block/iterable-go@latest (v0.0.0-20250904163840-1260cb393489) requires github.com/block/iterable-go@v0.0.0-20250904163840-1260cb393489: parsing go.mod:
        module declares its path as: iterable-go
                but was required as: github.com/block/iterable-go
```

This change renames the module: `iterable_go` -> `github.com/block/iterable-go`
and updates all imports to have the global name, for example:

```
import (
	iterable_go "github.com/block/iterable-go"
	"github.com/block/iterable-go/logger"
)
```

### Tests

`go get` works now:

```
go get github.com/block/iterable-go@iterable-go-github-block-iterable-go

go: downloading github.com/block/iterable-go v0.0.0-20250908214228-dcc028e0fc02
go: upgraded go 1.24.1 => 1.24.5
go: added github.com/block/iterable-go v0.0.0-20250908214228-dcc028e0fc02
go: upgraded github.com/stretchr/testify v1.10.0 => v1.11.1
```

Was able to pull the public repo and run tests
```
go get github.com/block/iterable-go@iterable-go-github-block-iterable-go

go mod tidy

go mod vendor

go test ./private-repo/...
```