### PR TITLE
Downgrades Go version: 1.24.5 -> 1.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/block/iterable-go
 
-go 1.24.5
+go 1.24.1
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
### Notes

For better compatibility.

### Tests

```
go build .
go build -C examples             
go test ./...
```