### PR TITLE
Do not retry 2xx responses

### DIFF
--- a/batch/utils.go
+++ b/batch/utils.go
@@ -99,10 +99,9 @@ func shouldRetry(err error) bool {
 	if err != nil {
 		if apiErr, ok := err.(*iterable_errors.ApiError); ok {
 			status := apiErr.HttpStatusCode
-			if status == 0 || status == 429 || // Deadline exceeded or rate limited
-				(status > 200 && (status < 400 || status >= 500)) { // Non 4xx error
-				return true
-			}
+			return status == 0 || // Request was not sent or context timed out
+				status == 429 || // Deadline exceeded or rate limited
+				status >= 500 // Any server error
 		}
 	}
 	return false


### PR DESCRIPTION
### Notes

`utils.shouldRetry` is used in a number of places. It checks if the error returned by the `api.apiClient` needs to be retried.

Before this change the `shouldRetry` function returned `true` for `statusCode` [201, 299].

Although, this is probably not possible, because the API shouldn't return an error in this case.

Let's change the `shouldRetry` to not attempt to retry a successful request.

### Tests
- no new tests