### PR TITLE
[Breaking Change] Changes contract of the batch.Handler interface

### DIFF
--- a/batch/batch_errors.go
+++ b/batch/batch_errors.go
@@ -1,0 +1,92 @@
+package batch
+
+import (
+	"errors"
+
+	iterable_errors "github.com/block/iterable-go/errors"
+)
+
+const (
+	ErrStrDisallowedEventName        = "Disallowed Event Name"
+	ErrStrConflictEmails             = "Email conflicts"
+	ErrStrConflictUserIds            = "UserId conflicts"
+	ErrStrForgottenEmails            = "Email Forgotten"
+	ErrStrForgottenUserIds           = "UserId Forgotten"
+	ErrStrInvalidDataEmails          = "Invalid Data"
+	ErrStrInvalidDataUserIds         = "Invalid Data"
+	ErrStrInvalidEmails              = "Malformed Email"
+	ErrStrInvalidUserIds             = "Malformed UserId"
+	ErrStrNotFoundEmails             = "Email not found"
+	ErrStrNotFoundUserIds            = "UserId not found"
+	ErrStrValidEmailFailures         = "Internal Error with Email"
+	ErrStrValidUserIdFailures        = "Internal Error with UserId"
+	ErrStrInvalidDataType            = "Invalid data type in batch request"
+	ErrStrInvalidListId              = "List ID not valid for Iterable project"
+	ErrStrInvalidBatchProcessorState = "InvalidBatchProcessorStateErr"
+	ErrStrProcessOneNotAllowed       = "ProcessOne is not allowed"
+	ErrStrProcessBatchNotAllowed     = "ProcessBatch is not allowed"
+	errStrIsDisallowedFromTracking   = "is disallowed from tracking"
+)
+
+var (
+	ErrInvalidListId              = errors.New(ErrStrInvalidListId)
+	ErrConflictEmails             = errors.New(ErrStrConflictEmails)
+	ErrConflictUserIds            = errors.New(ErrStrConflictUserIds)
+	ErrForgottenEmails            = errors.New(ErrStrForgottenEmails)
+	ErrForgottenUserIds           = errors.New(ErrStrForgottenUserIds)
+	ErrInvalidDataEmails          = errors.New(ErrStrInvalidDataEmails)
+	ErrInvalidDataUserIds         = errors.New(ErrStrInvalidDataUserIds)
+	ErrInvalidEmails              = errors.New(ErrStrInvalidEmails)
+	ErrInvalidUserIds             = errors.New(ErrStrInvalidUserIds)
+	ErrNotFoundEmails             = errors.New(ErrStrNotFoundEmails)
+	ErrNotFoundUserIds            = errors.New(ErrStrNotFoundUserIds)
+	ErrFieldTypeMismatch          = errors.New(iterable_errors.ITERABLE_FieldTypeMismatchErrStr)
+	ErrInvalidDataType            = errors.New(ErrStrInvalidDataType)
+	ErrValidEmailFailures         = errors.New(ErrStrValidEmailFailures)
+	ErrValidUserIdFailures        = errors.New(ErrStrValidUserIdFailures)
+	ErrDisallowedEventName        = errors.New(ErrStrDisallowedEventName)
+	ErrInvalidBatchProcessorState = errors.New(ErrStrInvalidBatchProcessorState)
+	ErrProcessOneNotAllowed       = errors.New(ErrStrProcessOneNotAllowed)
+	ErrProcessBatchNotAllowed     = errors.New(ErrStrProcessBatchNotAllowed)
+
+	// ErrClientValidationApiErr represents a client-side validation error that occurs before sending the request.
+	// This error indicates that the request data failed validation checks on the client side.
+	// It uses "fake" HttpStatusCode=400 to emphasize that retrying won't fix the issue.
+	ErrClientValidationApiErr = &iterable_errors.ApiError{
+		Stage:          iterable_errors.STAGE_BEFORE_REQUEST,
+		Type:           "data_validation_error",
+		HttpStatusCode: 400,
+		IterableCode:   "iterable_client_data_validation_error",
+	}
+
+	// ErrServerValidationApiErr represents a server-side validation error that occurs after sending the request.
+	// This error indicates that the request data failed validation checks on the server side with a 400 status code.
+	// "Real" HttpStatusCode might be 200, but the error uses "fake" HttpStatusCode=400
+	// to emphasize that retrying won't fix the issue.
+	ErrServerValidationApiErr = &iterable_errors.ApiError{
+		Stage:          iterable_errors.STAGE_AFTER_REQUEST,
+		Type:           "data_validation_error",
+		HttpStatusCode: 400,
+		IterableCode:   "iterable_server_data_validation_error",
+	}
+
+	// ErrClientMustRetryBatchApiErr indicates that the operation must be retried as a Batch request.
+	// Usually, this happens when sending single (non-batch) requests has some negative consequences,
+	// and we want to force the client of the library to send the same message as part of a Batch operation.
+	ErrClientMustRetryBatchApiErr = &iterable_errors.ApiError{
+		Stage:          iterable_errors.STAGE_BEFORE_REQUEST,
+		Type:           "must_retry",
+		HttpStatusCode: 500,
+		IterableCode:   "iterable_client_must_retry_batch",
+	}
+
+	// ErrClientMustRetryOneApiErr indicates that the operation must be retried as an individual
+	// request. Usually, this happens when sending a Batch request has some negative consequences,
+	// and we want to force the client of the library to send the same request individually.
+	ErrClientMustRetryOneApiErr = &iterable_errors.ApiError{
+		Stage:          iterable_errors.STAGE_BEFORE_REQUEST,
+		Type:           "must_retry",
+		HttpStatusCode: 500,
+		IterableCode:   "iterable_client_must_retry_one",
+	}
+)

--- a/batch/list_subscribe_test.go
+++ b/batch/list_subscribe_test.go
@@ -1,124 +1,261 @@
 package batch
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"testing"
 
 	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
 	"github.com/block/iterable-go/logger"
 	"github.com/block/iterable-go/rate"
 	"github.com/block/iterable-go/types"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListSubscribeBatchHandler_ProcessBatch(t *testing.T) {
 	tests := []struct {
-		name                    string
-		failCnt                 int
-		rateLimitCnt            int
-		uniqueIds               bool
-		noEmailCnt              int
-		expectedErr             bool
-		expectedRetry           bool
-		expectedReqCnt          int
-		expectedResLen          int
-		expectedIndividualRetry int
+		name             string
+		batchSize        int
+		invalidSize      int
+		resStatusCode    int
+		resBody          []byte
+		expectApiCalls   int
+		expectErr        bool
+		expectStatus     ProcessBatchResponse
+		expectMsgNoRetry int
+		expectMsgRetry   int
+		expectMsgError   int
+		expectMsgNoError int
 	}{
 		{
-			name:                    "Success",
-			failCnt:                 0,
-			rateLimitCnt:            0,
-			uniqueIds:               false,
-			expectedErr:             false,
-			expectedRetry:           false,
-			expectedReqCnt:          1,
-			expectedResLen:          10,
-			expectedIndividualRetry: 0,
+			name:             "Empty",
+			batchSize:        0,
+			resStatusCode:    200,
+			expectApiCalls:   0,
+			expectErr:        false,
+			expectStatus:     StatusSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   0,
+			expectMsgError:   0,
+			expectMsgNoError: 0,
 		},
 		{
-			name:                    "UniqueIds",
-			failCnt:                 0,
-			rateLimitCnt:            0,
-			uniqueIds:               true,
-			expectedErr:             false,
-			expectedRetry:           false,
-			expectedReqCnt:          10,
-			expectedResLen:          10,
-			expectedIndividualRetry: 0,
+			name:             "Success",
+			batchSize:        10,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":10}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   0,
+			expectMsgError:   0,
+			expectMsgNoError: 10,
 		},
 		{
-			name:                    "Fail",
-			failCnt:                 2,
-			rateLimitCnt:            0,
-			uniqueIds:               false,
-			expectedErr:             false,
-			expectedRetry:           false,
-			expectedReqCnt:          3,
-			expectedResLen:          10,
-			expectedIndividualRetry: 0,
+			name:             "Batch Request: 500 no body",
+			batchSize:        10,
+			resStatusCode:    500,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
 		},
 		{
-			name:                    "RateLimit",
-			failCnt:                 0,
-			rateLimitCnt:            3,
-			uniqueIds:               false,
-			expectedErr:             false,
-			expectedRetry:           false,
-			expectedReqCnt:          3,
-			expectedResLen:          10,
-			expectedIndividualRetry: 10,
+			name:             "Batch Request: 500 with body",
+			batchSize:        10,
+			resStatusCode:    500,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
 		},
 		{
-			name:                    "FailUnique",
-			failCnt:                 3,
-			rateLimitCnt:            0,
-			uniqueIds:               true,
-			expectedErr:             false,
-			expectedRetry:           false,
-			expectedReqCnt:          12,
-			expectedResLen:          10,
-			expectedIndividualRetry: 1,
-			noEmailCnt:              1,
+			name:             "Batch Request: 500 + ITERABLE_InvalidList",
+			batchSize:        10,
+			resStatusCode:    500,
+			resBody:          []byte(`{"msg":"123 error.lists.invalidListId abc"}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: RateLimit",
+			batchSize:        10,
+			resStatusCode:    429,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: ContentTooLarge",
+			batchSize:        10,
+			resStatusCode:    413,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Conflict",
+			batchSize:        10,
+			resStatusCode:    409,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Request Timeout",
+			batchSize:        10,
+			resStatusCode:    408,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Forbidden",
+			batchSize:        10,
+			resStatusCode:    403,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 400",
+			batchSize:        10,
+			resStatusCode:    400,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 400 + ITERABLE_InvalidList",
+			batchSize:        10,
+			resStatusCode:    400,
+			resBody:          []byte(`{"msg":"123 error.lists.invalidListId abc"}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 200 + invalid messages",
+			batchSize:        10,
+			invalidSize:      5,
+			resStatusCode:    200,
+			resBody:          []byte(`{}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 5,
+			expectMsgRetry:   0,
+			expectMsgError:   5,
+			expectMsgNoError: 10,
+		},
+		{
+			name:             "all messages are invalid",
+			invalidSize:      5,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":5}`), // never called
+			expectApiCalls:   0,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 5,
+			expectMsgRetry:   0,
+			expectMsgError:   5,
+			expectMsgNoError: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler, transport := testListSubscribeHandler(tt.failCnt, tt.rateLimitCnt)
-			batch := generateListSubTestBatchMessages(10, tt.uniqueIds, tt.noEmailCnt)
-			res, err, retry := handler.ProcessBatch(batch)
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testListSubscribeHandler(transport)
+			batch := generateListSubTestBatch(tt.batchSize, false, 0)
+			for range tt.invalidSize {
+				batch = append(batch, Message{
+					Data: "invalid",
+				})
+			}
 
-			if tt.expectedErr {
+			res, err := handler.ProcessBatch(batch)
+
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			if tt.expectErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tt.expectedResLen, len(res))
-			assert.Equal(t, tt.expectedRetry, retry)
-			assert.Equal(t, tt.expectedReqCnt, transport.reqCnt)
-			retryCount := 0
-			for _, r := range res {
-				if r.Retry {
-					retryCount++
-				}
+
+			if tt.expectStatus != nil {
+				assert.IsType(t, tt.expectStatus, res)
 			}
-			assert.Equal(t, tt.expectedIndividualRetry, retryCount)
+
+			msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+
+			assert.Equal(t, tt.expectMsgRetry, msgRetry)
+			assert.Equal(t, tt.expectMsgNoRetry, msgNoRetry)
+			assert.Equal(t, tt.expectMsgError, msgErr)
+			assert.Equal(t, tt.expectMsgNoError, msgNoErr)
 		})
 	}
 }
 
 func TestListSubscribeBatchHandler_ProcessBatch_DuplicateEmail(t *testing.T) {
-	handler, transport := testListSubscribeHandler(0, 0)
 	batch := []Message{
 		{
 			Data: &types.ListSubscribeRequest{
 				ListId: testListId,
 				Subscribers: []types.ListSubscriber{
-					{
-						Email: testEmail,
-					},
+					{Email: testEmail},
 				},
 			},
 		},
@@ -126,35 +263,29 @@ func TestListSubscribeBatchHandler_ProcessBatch_DuplicateEmail(t *testing.T) {
 			Data: &types.ListSubscribeRequest{
 				ListId: testListId,
 				Subscribers: []types.ListSubscriber{
-					{
-						Email: testEmail,
-					},
+					{Email: testEmail},
 				},
 			},
 		},
 	}
-	res, err, retry := handler.ProcessBatch(batch)
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, []byte(`{}`))
+	handler := testListSubscribeHandler(transport)
+
+	res, err := handler.ProcessBatch(batch)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(res))
-	assert.Equal(t, false, retry)
+	assert.IsType(t, StatusSuccess{}, res)
+	assert.Equal(t, 2, len(res.response()))
 
-	successCnt := 0
-	failCnt := 0
-	for _, r := range res {
-		if r.Error == nil {
-			successCnt++
-		} else {
-			failCnt++
-		}
-	}
-	assert.Equal(t, 2, successCnt)
-	assert.Equal(t, 0, failCnt)
-	assert.Equal(t, transport.reqCnt, 1)
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+	assert.Equal(t, 0, msgNoRetry)
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 2, msgNoErr)
+	assert.Equal(t, 0, msgErr)
 }
 
 func TestListSubscribeBatchHandler_ProcessBatch_DuplicateId(t *testing.T) {
-	handler, transport := testListSubscribeHandler(0, 0)
 	batch := []Message{
 		{
 			Data: &types.ListSubscribeRequest{
@@ -177,70 +308,215 @@ func TestListSubscribeBatchHandler_ProcessBatch_DuplicateId(t *testing.T) {
 			},
 		},
 	}
-	res, err, retry := handler.ProcessBatch(batch)
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, []byte(`{}`))
+	handler := testListSubscribeHandler(transport)
+
+	res, err := handler.ProcessBatch(batch)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(res))
-	assert.Equal(t, false, retry)
+	assert.IsType(t, StatusSuccess{}, res)
+	assert.Equal(t, 2, len(res.response()))
 
-	successCnt := 0
-	failCnt := 0
-	for _, r := range res {
-		if r.Error == nil {
-			successCnt++
-		} else {
-			failCnt++
-		}
-	}
-	assert.Equal(t, 2, successCnt)
-	assert.Equal(t, 0, failCnt)
-	assert.Equal(t, transport.reqCnt, 1)
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+	assert.Equal(t, 0, msgNoRetry)
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 2, msgNoErr)
+	assert.Equal(t, 0, msgErr)
 }
 
-func TestListSubscribeBatchHandler_ProcessBatch_InvalidData(t *testing.T) {
-	handler, transport := testListSubscribeHandler(0, 0)
-	batch := []Message{
-		{
-			Data: "invalid",
+func TestListSubscribeBatchHandler_ProcessBatch_PartialSuccess(t *testing.T) {
+	list1Res := types.ListSubscribeResponse{
+		FailedUpdates: types.FailedUpdates{
+			ConflictEmails:  []string{"email1@example.com"},
+			ConflictUserIds: []string{"email1"},
 		},
 	}
-	res, err, retry := handler.ProcessBatch(batch)
+	list2Res := types.ListSubscribeResponse{
+		FailedUpdates: types.FailedUpdates{
+			ForgottenEmails:    []string{"email2@example.com"},
+			ForgottenUserIds:   []string{"email2"},
+			InvalidDataEmails:  []string{"email3@example.com"},
+			InvalidDataUserIds: []string{"email3"},
+			InvalidEmails:      []string{"email4@example.com"},
+			InvalidUserIds:     []string{"email4"},
+		},
+	}
+	list3Res := types.ListSubscribeResponse{
+		FailedUpdates: types.FailedUpdates{
+			NotFoundEmails:  []string{"email5@example.com"},
+			NotFoundUserIds: []string{"email5"},
+		},
+	}
+	list4Res := types.ListSubscribeResponse{}
+	req := []Message{
+		{Data: "invalid"},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      1,
+			Subscribers: []types.ListSubscriber{{Email: "email1@example.com"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      1,
+			Subscribers: []types.ListSubscriber{{UserId: "email1"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      2,
+			Subscribers: []types.ListSubscriber{{Email: "email2@example.com"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      2,
+			Subscribers: []types.ListSubscriber{{UserId: "email2"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      2,
+			Subscribers: []types.ListSubscriber{{Email: "email3@example.com"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      2,
+			Subscribers: []types.ListSubscriber{{UserId: "email3"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      2,
+			Subscribers: []types.ListSubscriber{{Email: "email4@example.com"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      2,
+			Subscribers: []types.ListSubscriber{{UserId: "email4"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      3,
+			Subscribers: []types.ListSubscriber{{Email: "email5@example.com"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      3,
+			Subscribers: []types.ListSubscriber{{UserId: "email5"}},
+		}},
 
+		// Successful
+		{Data: &types.ListSubscribeRequest{
+			ListId:      3,
+			Subscribers: []types.ListSubscriber{{Email: "email6@example.com"}},
+		}},
+		{Data: &types.ListSubscribeRequest{
+			ListId:      4,
+			Subscribers: []types.ListSubscriber{{UserId: "email6"}},
+		}},
+	}
+
+	transport := NewFakeTransport(0, 0)
+
+	// expect 4 calls, because there are 4 distinct list ids
+	data1, _ := json.Marshal(list1Res)
+	data2, _ := json.Marshal(list2Res)
+	data3, _ := json.Marshal(list3Res)
+	data4, _ := json.Marshal(list4Res)
+	transport.AddResponseQueue(200, data1)
+	transport.AddResponseQueue(200, data2)
+	transport.AddResponseQueue(200, data3)
+	transport.AddResponseQueue(200, data4)
+
+	handler := testListSubscribeHandler(transport)
+	res, err := handler.ProcessBatch(req)
+
+	assert.Equal(t, 4, transport.reqCnt)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(res))
-	assert.Equal(t, false, retry)
-	assert.Equal(t, transport.reqCnt, 0)
+	assert.IsType(t, StatusPartialSuccess{}, res)
+	assert.Equal(t, len(req), len(res.response()))
 
-	assert.Error(t, res[0].Error)
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 11, msgNoRetry)
+	assert.Equal(t, 11, msgErr)
+	assert.Equal(t, 2, msgNoErr)
 }
 
 func TestListSubscribeBatchHandler_ProcessOne(t *testing.T) {
-	handler, transport := testListSubscribeHandler(0, 0)
-	batch := generateListSubTestBatchMessages(10, false, 0)
-
-	res := make([]Response, 0, len(batch))
-	for _, req := range batch {
-		newRes := handler.ProcessOne(req)
-		assert.True(t, newRes.Retry)
-		res = append(res, newRes)
+	tests := []struct {
+		name           string
+		resStatusCode  int
+		resBody        []byte
+		expectApiCalls int
+		expectErr      bool
+		expectRetry    bool
+	}{
+		{
+			name:           "Success",
+			resStatusCode:  200,
+			resBody:        []byte(`{"code":"200"}`),
+			expectApiCalls: 1,
+		},
+		{
+			name:           "status:0",
+			resStatusCode:  0,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:500",
+			resStatusCode:  500,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:408",
+			resStatusCode:  408,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:429",
+			resStatusCode:  408,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:409",
+			resStatusCode:  409,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    false,
+		},
+		{
+			name:           "status:400",
+			resStatusCode:  400,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    false,
+		},
 	}
 
-	assert.Equal(t, 10, len(res))
-	assert.Equal(t, transport.reqCnt, 0)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testListSubscribeHandler(transport)
 
-func TestListSubscribeBatchHandler_ProcessOne_InvalidData(t *testing.T) {
-	handler, transport := testListSubscribeHandler(0, 0)
-	req := Message{
-		Data: "invalid",
+			req := generateListSubTestBatch(1, false, 0)[0]
+			res := handler.ProcessOne(req)
+
+			assert.ErrorIs(t, res.Error, ErrProcessOneNotAllowed)
+			assert.ErrorIs(t, res.Error, ErrClientMustRetryBatchApiErr)
+			var apiErr *iterable_errors.ApiError
+			ok := errors.As(res.Error, &apiErr)
+			require.True(t, ok)
+			assert.Equal(t, 500, apiErr.HttpStatusCode)
+			assert.True(t, res.Retry)
+			assert.Equal(t, 0, transport.reqCnt)
+		})
 	}
-	res := handler.ProcessOne(req)
-
-	assert.Equal(t, transport.reqCnt, 0)
-	assert.Error(t, res.Error)
 }
 
-func generateListSubTestBatchMessages(cnt int, uniqueIds bool, noEmailCnt int) []Message {
+func generateListSubTestBatch(cnt int, uniqueIds bool, noEmailCnt int) []Message {
 	var batch []Message
 	listId := testListId
 	for i := range cnt {
@@ -277,11 +553,11 @@ func generateListSubTestBatchMessages(cnt int, uniqueIds bool, noEmailCnt int) [
 	return batch
 }
 
-func testListSubscribeHandler(failCnt int, rateLimitCnt int) (*listSubscribeHandler, *fakeTransport) {
-	transport := NewFakeTransport(failCnt, rateLimitCnt)
+func testListSubscribeHandler(transport http.RoundTripper) *listSubscribeHandler {
+	//transport := NewFakeTransport(failCnt, rateLimitCnt)
 	httpClient := http.Client{}
 	httpClient.Transport = transport
 	lists := api.NewListsApi("test", &httpClient, &logger.Noop{}, &rate.NoopLimiter{})
 	handler := NewListSubscribeHandler(lists, &logger.Noop{})
-	return handler.(*listSubscribeHandler), transport
+	return handler.(*listSubscribeHandler)
 }

--- a/batch/list_unsubscribe.go
+++ b/batch/list_unsubscribe.go
@@ -2,13 +2,12 @@ package batch
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
-	"time"
 
 	"github.com/block/iterable-go/api"
 	iterable_errors "github.com/block/iterable-go/errors"
 	"github.com/block/iterable-go/logger"
-	"github.com/block/iterable-go/retry"
 	"github.com/block/iterable-go/types"
 )
 
@@ -32,7 +31,6 @@ func newListUnSubscribeBatch(listId int64) *listUnSubscribeBatch {
 type listUnSubscribeHandler struct {
 	client *api.Lists
 	logger logger.Logger
-	retry  retry.Retry
 }
 
 var _ Handler = &listUnSubscribeHandler{}
@@ -44,87 +42,105 @@ func NewListUnSubscribeBatchHandler(
 	return &listUnSubscribeHandler{
 		client: client,
 		logger: logger,
-		retry: retry.NewExponentialRetry(
-			retry.WithInitialDuration(10*time.Millisecond),
-			retry.WithLogger(logger),
-		),
 	}
 }
 
-func (s *listUnSubscribeHandler) ProcessBatch(batch []Message) ([]Response, error, bool) {
-	// Convert Message to multiple ListUnSubscribeRequests by listId and create maps of email/userId to request
-	batchReqMap, responses := s.generatePayloads(batch)
+func (s *listUnSubscribeHandler) ProcessBatch(batch []Message) (ProcessBatchResponse, error) {
+	batchReqs, cannotRetry := s.generatePayloads(batch)
+
+	var result []Response
+	result = append(result, cannotRetry...)
+	if len(batchReqs) == 0 {
+		if len(cannotRetry) != 0 {
+			return StatusCannotRetry{result}, nil
+		}
+		return StatusSuccess{result}, nil
+	}
 
 	// Process each batch of ListUnSubscribeRequests
-	for _, batchReq := range batchReqMap {
-		var res *types.ListUnSubscribeResponse
-		var err error
-		err = s.retry.Do(3, "list-unsubscribe", func(attempt int) (error, retry.ExitStrategy) {
-			res, err = s.client.UnSubscribe(batchReq.batch)
-			s.logger.Debugf("ListSubscribe response: %+v, err: %+v", res, err)
-			if shouldRetry(err) {
-				return err, retry.Continue
-			} else {
-				return err, retry.StopNow
-			}
-		})
-		// Check for failures and return error if it is retriable
-		// This will cause the entire batch to be retried
-		if err != nil {
-			if apiErr := err.(*iterable_errors.ApiError); apiErr != nil {
-				resp := &types.PostResponse{}
-				errU := json.Unmarshal(apiErr.Body, resp)
-				if errU == nil {
-					// Search for this specifically because the API returns "success" as the code, but it isn't a success
-					if strings.Contains(resp.Message, iterable_errors.ITERABLE_InvalidList) {
-						responses = addReqFailuresToResponses(batchReq.reqByEmailMap, responses, InvalidListId, false)
-						responses = addReqFailuresToResponses(batchReq.reqByUserIdMap, responses, InvalidListId, false)
-					} else {
-						responses = addReqFailuresToResponses(batchReq.reqByEmailMap, responses, apiErr.IterableCode, shouldRetry(err))
-						responses = addReqFailuresToResponses(batchReq.reqByUserIdMap, responses, apiErr.IterableCode, shouldRetry(err))
-					}
-				}
-			} else {
-				// If there is some non-API error, log it but don't retry
-				responses = addReqFailuresToResponses(batchReq.reqByEmailMap, responses, UnknownError, true)
-			}
-		} else {
-			// Map email/userId failures back to requests
-			responses = parseReqFailures(res.FailedUpdates.ConflictEmails, batchReq.reqByEmailMap, responses, ConflictEmailsErr)
-			responses = parseReqFailures(res.FailedUpdates.ConflictUserIds, batchReq.reqByUserIdMap, responses, ConflictUserIdsErr)
-			responses = parseReqFailures(res.FailedUpdates.ForgottenEmails, batchReq.reqByEmailMap, responses, ForgottenEmailsErr)
-			responses = parseReqFailures(res.FailedUpdates.ForgottenUserIds, batchReq.reqByUserIdMap, responses, ForgottenUserIdsErr)
-			responses = parseReqFailures(res.FailedUpdates.InvalidDataEmails, batchReq.reqByEmailMap, responses, InvalidDataEmailsErr)
-			responses = parseReqFailures(res.FailedUpdates.InvalidDataUserIds, batchReq.reqByUserIdMap, responses, InvalidDataUserIdsErr)
-			responses = parseReqFailures(res.FailedUpdates.InvalidEmails, batchReq.reqByEmailMap, responses, InvalidEmailsErr)
-			responses = parseReqFailures(res.FailedUpdates.InvalidUserIds, batchReq.reqByUserIdMap, responses, InvalidUserIdsErr)
-			responses = parseReqFailures(res.FailedUpdates.NotFoundEmails, batchReq.reqByEmailMap, responses, NotFoundEmailsErr)
-			responses = parseReqFailures(res.FailedUpdates.NotFoundUserIds, batchReq.reqByUserIdMap, responses, NotFoundUserIdsErr)
+	for _, batchReq := range batchReqs {
+		res, err := s.client.UnSubscribe(batchReq.batch)
 
-			// Add success to remaining requests
-			responses = addReqSuccessToResponses(batchReq.reqByEmailMap, responses)
-			responses = addReqSuccessToResponses(batchReq.reqByUserIdMap, responses)
+		if err != nil {
+			messages := flatValues(batchReq.reqByEmailMap, batchReq.reqByUserIdMap)
+
+			var apiErr *iterable_errors.ApiError
+			if !errors.As(err, &apiErr) || apiErr == nil {
+				result = append(result, toFailures(messages, err, false)...)
+				continue
+			}
+
+			res2 := types.PostResponse{}
+			errU := json.Unmarshal(apiErr.Body, &res2)
+			if errU != nil {
+				err2 := errors.Join(errU, err)
+				// If there's 1 bad message that makes the json invalid,
+				// retrying individually should allow us to find the message.
+				result = append(result, toFailures(messages, err2, true)...)
+				continue
+			}
+
+			// Search for the prefix specifically because the API returns "success" as the code,
+			// but it isn't a success
+			if strings.Contains(res2.Message, iterable_errors.ITERABLE_InvalidList) {
+				err2 := errors.Join(ErrInvalidListId, err)
+				result = append(result, toFailures(messages, err2, false)...)
+				continue
+			}
+
+			// Never return StatusRetryBatch, because one call to ProcessBatch
+			// spawns multiple calls to Iterable.
+			if batchCanRetryOne(apiErr) {
+				result = append(result, toFailures(messages, err, true)...)
+				continue
+			}
+
+			result = append(result, toFailures(messages, err, false)...)
+			continue
+		}
+
+		var sentAndFailed []Response
+		f := res.FailedUpdates
+		// Map email/userId failures back to requests
+		sentAndFailed = append(sentAndFailed, parseFailures(f.ConflictEmails, batchReq.reqByEmailMap, ErrConflictEmails)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.ConflictUserIds, batchReq.reqByUserIdMap, ErrConflictUserIds)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.ForgottenEmails, batchReq.reqByEmailMap, ErrForgottenEmails)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.ForgottenUserIds, batchReq.reqByUserIdMap, ErrForgottenUserIds)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidDataEmails, batchReq.reqByEmailMap, ErrInvalidDataEmails)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidDataUserIds, batchReq.reqByUserIdMap, ErrInvalidDataUserIds)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidEmails, batchReq.reqByEmailMap, ErrInvalidEmails)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidUserIds, batchReq.reqByUserIdMap, ErrInvalidUserIds)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.NotFoundEmails, batchReq.reqByEmailMap, ErrNotFoundEmails)...)
+		sentAndFailed = append(sentAndFailed, parseFailures(f.NotFoundUserIds, batchReq.reqByUserIdMap, ErrNotFoundUserIds)...)
+
+		result = append(result, sentAndFailed...)
+		result = append(result, toSuccess(batchReq.reqByEmailMap)...)
+		result = append(result, toSuccess(batchReq.reqByUserIdMap)...)
+	}
+
+	for _, r := range result {
+		if r.Error != nil {
+			return StatusPartialSuccess{result}, nil
 		}
 	}
 
-	return responses, nil, false
+	return StatusSuccess{result}, nil
 }
 
 func (s *listUnSubscribeHandler) ProcessOne(req Message) Response {
 	// This is a no-op for the listUnSubscribeHandler, we don't want to send
-	// individual requests for ListUnSubscribe since it will use up our rate limit
-	// We can nack the message and it should get retried as a batches
-	return Response{
-		OriginalReq: req,
-		Error:       NoIndividualRetryError,
-		Retry:       true,
-	}
+	// individual requests for ListUnSubscribe since it will use up our rate limit.
+	// We can nack the message, it should get retried as a batches.
+	err := errors.Join(ErrProcessOneNotAllowed, ErrClientMustRetryBatchApiErr)
+	return toFailure(req, err, true)
 }
 
 func (s *listUnSubscribeHandler) generatePayloads(
 	messages []Message,
-) (map[int64]*listUnSubscribeBatch, []Response) {
-	var responses []Response
+) ([]*listUnSubscribeBatch, []Response) {
+	var batchReqs []*listUnSubscribeBatch
+	var cannotRetry []Response
+
 	batchMap := make(map[int64]*listUnSubscribeBatch)
 	for _, req := range messages {
 		if subData, ok := req.Data.(*types.ListUnSubscribeRequest); ok {
@@ -132,6 +148,7 @@ func (s *listUnSubscribeHandler) generatePayloads(
 			if !batchFound {
 				newBatch = newListUnSubscribeBatch(subData.ListId)
 				batchMap[subData.ListId] = newBatch
+				batchReqs = append(batchReqs, newBatch)
 			}
 
 			for _, subscriber := range subData.Subscribers {
@@ -143,13 +160,15 @@ func (s *listUnSubscribeHandler) generatePayloads(
 				newBatch.batch.Subscribers = append(newBatch.batch.Subscribers, subscriber)
 			}
 		} else {
-			s.logger.Errorf("Invalid data type in ListUnSubscribe batch request")
-			responses = append(responses, Response{
-				OriginalReq: req,
-				Error:       InvalidDataErr,
-			})
+			s.logger.Errorf("Invalid data type in ListUnSubscribe/ProcessBatch: %t", req.Data)
+			m := toFailure(
+				req,
+				errors.Join(ErrInvalidDataType, ErrClientValidationApiErr),
+				false,
+			)
+			cannotRetry = append(cannotRetry, m)
 		}
 	}
 
-	return batchMap, responses
+	return batchReqs, cannotRetry
 }

--- a/batch/subscription_update.go
+++ b/batch/subscription_update.go
@@ -1,7 +1,10 @@
 package batch
 
 import (
+	"errors"
+
 	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
 	"github.com/block/iterable-go/logger"
 	"github.com/block/iterable-go/types"
 )
@@ -39,45 +42,72 @@ func NewSubscriptionUpdateHandler(
 	}
 }
 
-func (s *subscriptionUpdateHandler) ProcessBatch(batch []Message) ([]Response, error, bool) {
-	batchReq, responses := s.generatePayloads(batch)
+func (s *subscriptionUpdateHandler) ProcessBatch(batch []Message) (ProcessBatchResponse, error) {
+	req, cannotRetry := s.generatePayloads(batch)
 
-	res, err := s.Client.BulkUpdateSubscriptions(batchReq.batch)
+	var result []Response
+	result = append(result, cannotRetry...)
+	if len(req.batch.UpdateSubscriptionsRequests) == 0 {
+		if len(cannotRetry) != 0 {
+			return StatusCannotRetry{result}, nil
+		}
+		return StatusSuccess{result}, nil
+	}
+
+	res, err := s.Client.BulkUpdateSubscriptions(req.batch)
 	s.logger.Debugf("BulkUpdateSubscriptions response: %+v, err: %+v", res, err)
 	// Check for failures and return error if it is retriable
 	if err != nil {
-		return nil, err, shouldRetry(err)
-	} else {
-		// Map email/userId failures back to requests
-		responses = parseReqFailures(res.InvalidEmails, batchReq.reqByEmailMap, responses, InvalidEmailsErr)
-		responses = parseReqFailures(res.InvalidUserIds, batchReq.reqByUserIdMap, responses, InvalidUserIdsErr)
-		responses = parseReqFailures(res.ValidEmailFailures, batchReq.reqByEmailMap, responses, ValidEmailFailures)
-		responses = parseReqFailures(res.ValidUserIdFailures, batchReq.reqByUserIdMap, responses, ValidUserIdFailures)
+		var apiErr *iterable_errors.ApiError
+		if !errors.As(err, &apiErr) || apiErr == nil {
+			return nil, err
+		}
 
-		// Add success to remaining requests
-		responses = addReqSuccessToResponses(batchReq.reqByEmailMap, responses)
-		responses = addReqSuccessToResponses(batchReq.reqByUserIdMap, responses)
+		messages := flatValues(req.reqByEmailMap, req.reqByUserIdMap)
+		return handleBatchError(apiErr, result, messages)
 	}
 
-	return responses, nil, false
+	var sentAndFailed []Response
+	// Map email/userId failures back to requests
+	sentAndFailed = append(sentAndFailed, parseFailures(res.InvalidEmails, req.reqByEmailMap, ErrInvalidEmails)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(res.InvalidUserIds, req.reqByUserIdMap, ErrInvalidUserIds)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(res.ValidEmailFailures, req.reqByEmailMap, ErrValidEmailFailures)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(res.ValidUserIdFailures, req.reqByUserIdMap, ErrValidUserIdFailures)...)
+
+	result = append(result, sentAndFailed...)
+	result = append(result, toSuccess(req.reqByEmailMap)...)
+	result = append(result, toSuccess(req.reqByUserIdMap)...)
+
+	if len(cannotRetry) == 0 && len(sentAndFailed) == 0 {
+		return StatusSuccess{result}, nil
+	}
+	return StatusPartialSuccess{result}, nil
 }
 
 func (s *subscriptionUpdateHandler) ProcessOne(req Message) Response {
 	var res Response
-	if subData, ok := req.Data.(*types.UserUpdateSubscriptionsRequest); ok {
-		_, err := s.Client.UpdateSubscriptions(*subData)
+	if data, ok := req.Data.(*types.UserUpdateSubscriptionsRequest); ok {
+		_, err := s.Client.UpdateSubscriptions(*data)
+		if err != nil {
+			s.logger.Debugf("Failed to process SubscriptionUpdate/ProcessOne: %v", err)
+		}
+
 		res = Response{
 			OriginalReq: req,
 			Error:       err,
-			Retry:       shouldRetry(err),
+			Retry:       oneCanRetry(err),
 		}
 	} else {
-		s.logger.Errorf("Invalid data type in SubscriptionUpdate batch request")
+		s.logger.Errorf("Invalid data type in SubscriptionUpdate/ProcessOne: %t", req.Data)
 		res = Response{
 			OriginalReq: req,
-			Error:       InvalidDataErr,
+			Error: errors.Join(
+				ErrInvalidDataType,
+				ErrClientValidationApiErr,
+			),
 		}
 	}
+	s.logger.Debugf("Successfully sent SubscriptionUpdate/ProcessOne")
 
 	return res
 }
@@ -85,24 +115,28 @@ func (s *subscriptionUpdateHandler) ProcessOne(req Message) Response {
 func (s *subscriptionUpdateHandler) generatePayloads(
 	messages []Message,
 ) (*subscriptionUpdateBatch, []Response) {
-	var responses []Response
+	var cannotRetry []Response
 	newBatch := newSubscriptionUpdateBatch()
 	for _, req := range messages {
-		if subData, ok := req.Data.(*types.UserUpdateSubscriptionsRequest); ok {
-			if subData.Email != "" {
-				addReqToMap(newBatch.reqByEmailMap, req, subData.Email)
+		if data, ok := req.Data.(*types.UserUpdateSubscriptionsRequest); ok {
+			if data.Email != "" {
+				addReqToMap(newBatch.reqByEmailMap, req, data.Email)
 			} else {
-				addReqToMap(newBatch.reqByUserIdMap, req, subData.UserId)
+				addReqToMap(newBatch.reqByUserIdMap, req, data.UserId)
 			}
-			newBatch.batch.UpdateSubscriptionsRequests = append(newBatch.batch.UpdateSubscriptionsRequests, *subData)
+			newBatch.batch.UpdateSubscriptionsRequests = append(
+				newBatch.batch.UpdateSubscriptionsRequests, *data,
+			)
 		} else {
-			s.logger.Errorf("Invalid data type in SubscriptionUpdate batch request")
-			responses = append(responses, Response{
-				OriginalReq: req,
-				Error:       InvalidDataErr,
-			})
+			s.logger.Errorf("Invalid data type in SubscriptionUpdate/ProcessBatch: %t", req.Data)
+			m := toFailure(
+				req,
+				errors.Join(ErrInvalidDataType, ErrClientValidationApiErr),
+				false,
+			)
+			cannotRetry = append(cannotRetry, m)
 		}
 	}
 
-	return newBatch, responses
+	return newBatch, cannotRetry
 }

--- a/batch/subscription_update_test.go
+++ b/batch/subscription_update_test.go
@@ -1,72 +1,214 @@
 package batch
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"testing"
 
 	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
 	"github.com/block/iterable-go/logger"
 	"github.com/block/iterable-go/rate"
 	"github.com/block/iterable-go/types"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubscriptionUpdateBatchHandler_ProcessBatch(t *testing.T) {
 	tests := []struct {
-		name           string
-		failCnt        int
-		rateLimitCnt   int
-		expectedErr    bool
-		expectedRetry  bool
-		expectedResLen int
+		name             string
+		batchSize        int
+		invalidSize      int
+		resStatusCode    int
+		resBody          []byte
+		expectApiCalls   int
+		expectErr        bool
+		expectStatus     ProcessBatchResponse
+		expectMsgNoRetry int
+		expectMsgRetry   int
+		expectMsgError   int
+		expectMsgNoError int
 	}{
 		{
-			name:           "Success",
-			failCnt:        0,
-			rateLimitCnt:   0,
-			expectedErr:    false,
-			expectedRetry:  false,
-			expectedResLen: 10,
+			name:             "Empty",
+			batchSize:        0,
+			resStatusCode:    200,
+			expectApiCalls:   0,
+			expectErr:        false,
+			expectStatus:     StatusSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   0,
+			expectMsgError:   0,
+			expectMsgNoError: 0,
 		},
 		{
-			name:           "Fail",
-			failCnt:        1,
-			rateLimitCnt:   0,
-			expectedErr:    true,
-			expectedRetry:  true,
-			expectedResLen: 0,
+			name:             "Success",
+			batchSize:        10,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":10}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   0,
+			expectMsgError:   0,
+			expectMsgNoError: 10,
 		},
 		{
-			name:           "RateLimit",
-			failCnt:        0,
-			rateLimitCnt:   1,
-			expectedErr:    true,
-			expectedRetry:  true,
-			expectedResLen: 0,
+			name:             "Batch Request: 500",
+			batchSize:        10,
+			resStatusCode:    500,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryBatch{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: RateLimit",
+			batchSize:        10,
+			resStatusCode:    429,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryBatch{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: ContentTooLarge",
+			batchSize:        10,
+			resStatusCode:    413,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Conflict",
+			batchSize:        10,
+			resStatusCode:    409,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Request Timeout",
+			batchSize:        10,
+			resStatusCode:    408,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Forbidden",
+			batchSize:        10,
+			resStatusCode:    403,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 400",
+			batchSize:        10,
+			resStatusCode:    400,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 200 + invalid messages",
+			batchSize:        10,
+			invalidSize:      5,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":10}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 5,
+			expectMsgRetry:   0,
+			expectMsgError:   5,
+			expectMsgNoError: 10,
+		},
+		{
+			name:             "all messages are invalid",
+			invalidSize:      5,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":5}`), // never called
+			expectApiCalls:   0,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 5,
+			expectMsgRetry:   0,
+			expectMsgError:   5,
+			expectMsgNoError: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := testSubscriptionUpdateHandler(tt.failCnt, tt.rateLimitCnt)
-			batch := generateUserSubUpdateTestBatchMessages(10)
-			res, err, retry := handler.ProcessBatch(batch)
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testSubscriptionUpdateHandler(transport)
+			batch := generateUserSubUpdateTestBatch(tt.batchSize)
+			for range tt.invalidSize {
+				batch = append(batch, Message{
+					Data: "invalid",
+				})
+			}
 
-			if tt.expectedErr {
+			res, err := handler.ProcessBatch(batch)
+
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			if tt.expectErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tt.expectedResLen, len(res))
-			assert.Equal(t, tt.expectedRetry, retry)
+
+			if tt.expectStatus != nil {
+				assert.IsType(t, tt.expectStatus, res)
+			}
+
+			msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+
+			assert.Equal(t, tt.expectMsgRetry, msgRetry)
+			assert.Equal(t, tt.expectMsgNoRetry, msgNoRetry)
+			assert.Equal(t, tt.expectMsgError, msgErr)
+			assert.Equal(t, tt.expectMsgNoError, msgNoErr)
 		})
 	}
 }
 
 func TestSubscriptionUpdateBatchHandler_ProcessBatch_DuplicateEmail(t *testing.T) {
-	handler := testSubscriptionUpdateHandler(0, 0)
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, []byte(`{}`))
+	handler := testSubscriptionUpdateHandler(transport)
+
 	batch := []Message{
 		{
 			Data: &types.UserUpdateSubscriptionsRequest{
@@ -79,27 +221,24 @@ func TestSubscriptionUpdateBatchHandler_ProcessBatch_DuplicateEmail(t *testing.T
 			},
 		},
 	}
-	res, err, retry := handler.ProcessBatch(batch)
+	res, err := handler.ProcessBatch(batch)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(res))
-	assert.Equal(t, false, retry)
+	assert.IsType(t, StatusSuccess{}, res)
+	assert.Equal(t, 2, len(res.response()))
 
-	successCnt := 0
-	failCnt := 0
-	for _, r := range res {
-		if r.Error == nil {
-			successCnt++
-		} else {
-			failCnt++
-		}
-	}
-	assert.Equal(t, 2, successCnt)
-	assert.Equal(t, 0, failCnt)
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+	assert.Equal(t, 0, msgNoRetry)
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 2, msgNoErr)
+	assert.Equal(t, 0, msgErr)
 }
 
 func TestSubscriptionUpdateBatchHandler_ProcessBatch_DuplicateId(t *testing.T) {
-	handler := testSubscriptionUpdateHandler(0, 0)
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, []byte(`{}`))
+	handler := testSubscriptionUpdateHandler(transport)
+
 	batch := []Message{
 		{
 			Data: &types.UserUpdateSubscriptionsRequest{
@@ -112,64 +251,174 @@ func TestSubscriptionUpdateBatchHandler_ProcessBatch_DuplicateId(t *testing.T) {
 			},
 		},
 	}
-	res, err, retry := handler.ProcessBatch(batch)
+	res, err := handler.ProcessBatch(batch)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(res))
-	assert.Equal(t, false, retry)
+	assert.IsType(t, StatusSuccess{}, res)
+	assert.Equal(t, 2, len(res.response()))
 
-	successCnt := 0
-	failCnt := 0
-	for _, r := range res {
-		if r.Error == nil {
-			successCnt++
-		} else {
-			failCnt++
-		}
-	}
-	assert.Equal(t, 2, successCnt)
-	assert.Equal(t, 0, failCnt)
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+	assert.Equal(t, 0, msgNoRetry)
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 2, msgNoErr)
+	assert.Equal(t, 0, msgErr)
 }
 
-func TestSubscriptionUpdateBatchHandler_ProcessBatch_InvalidData(t *testing.T) {
-	handler := testSubscriptionUpdateHandler(0, 0)
-	batch := []Message{
-		{
-			Data: "invalid",
-		},
+func TestSubscriptionUpdateBatchHandle_ProcessBatch_PartialSuccess(t *testing.T) {
+	res := types.BulkUserUpdateSubscriptionsResponse{
+		SuccessCount:        0,
+		FailCount:           4,
+		InvalidEmails:       []string{"email1@example.com"},
+		InvalidUserIds:      []string{"email1"},
+		ValidEmailFailures:  []string{"email2@example.com"},
+		ValidUserIdFailures: []string{"email2"},
 	}
-	res, err, retry := handler.ProcessBatch(batch)
+	data, _ := json.Marshal(res)
+	req := []Message{
+		{Data: "invalid"},
+		{Data: &types.UserUpdateSubscriptionsRequest{
+			Email: "email1@example.com",
+		}},
+		{Data: &types.UserUpdateSubscriptionsRequest{
+			UserId: "email1",
+		}},
+		{Data: &types.UserUpdateSubscriptionsRequest{
+			Email: "email2@example.com",
+		}},
+		{Data: &types.UserUpdateSubscriptionsRequest{
+			UserId: "email2",
+		}},
 
+		// Successful
+		{Data: &types.UserUpdateSubscriptionsRequest{Email: "email6@example.com"}},
+		{Data: &types.UserUpdateSubscriptionsRequest{UserId: "email6"}},
+	}
+
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, data)
+	handler := testSubscriptionUpdateHandler(transport)
+	res2, err := handler.ProcessBatch(req)
+
+	assert.Equal(t, 1, transport.reqCnt)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(res))
-	assert.Equal(t, false, retry)
+	assert.IsType(t, StatusPartialSuccess{}, res2)
+	assert.Equal(t, len(req), len(res2.response()))
 
-	assert.Error(t, res[0].Error)
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res2.response())
+
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 5, msgNoRetry)
+	assert.Equal(t, 5, msgErr)
+	assert.Equal(t, 2, msgNoErr)
 }
 
 func TestSubscriptionUpdateBatchHandler_ProcessOne(t *testing.T) {
-	handler := testSubscriptionUpdateHandler(0, 0)
-	batch := generateUserSubUpdateTestBatchMessages(10)
-
-	res := make([]Response, 0, len(batch))
-	for _, req := range batch {
-		res = append(res, handler.ProcessOne(req))
+	tests := []struct {
+		name           string
+		resStatusCode  int
+		resBody        []byte
+		expectApiCalls int
+		expectErr      bool
+		expectRetry    bool
+	}{
+		{
+			name:           "status:200",
+			resStatusCode:  200,
+			resBody:        []byte(`{"code":"200"}`),
+			expectApiCalls: 1,
+		},
+		{
+			name:           "status:0",
+			resStatusCode:  0,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:500",
+			resStatusCode:  500,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:408",
+			resStatusCode:  408,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:429",
+			resStatusCode:  408,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:409",
+			resStatusCode:  409,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    false,
+		},
+		{
+			name:           "status:400",
+			resStatusCode:  400,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    false,
+		},
 	}
 
-	assert.Equal(t, 10, len(res))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testSubscriptionUpdateHandler(transport)
+
+			req := generateUserSubUpdateTestOne()
+			res := handler.ProcessOne(req)
+
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			if tt.expectErr {
+				assert.Error(t, res.Error)
+				assert.Equal(t, tt.expectRetry, res.Retry)
+			} else {
+				assert.NoError(t, res.Error)
+				assert.False(t, res.Retry)
+			}
+		})
+	}
 }
 
 func TestSubscriptionUpdateBatchHandler_ProcessOne_InvalidData(t *testing.T) {
-	handler := testSubscriptionUpdateHandler(0, 0)
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, []byte(`{}`))
+	handler := testSubscriptionUpdateHandler(transport)
 	req := Message{
 		Data: "invalid",
 	}
 	res := handler.ProcessOne(req)
 
+	assert.Equal(t, 0, transport.reqCnt)
 	assert.Error(t, res.Error)
+	assert.ErrorIs(t, res.Error, ErrInvalidDataType)
+	assert.ErrorIs(t, res.Error, ErrClientValidationApiErr)
+	var apiErr *iterable_errors.ApiError
+	ok := errors.As(res.Error, &apiErr)
+	require.True(t, ok)
+	assert.Equal(t, 400, apiErr.HttpStatusCode)
+	assert.False(t, res.Retry)
 }
 
-func generateUserSubUpdateTestBatchMessages(cnt int) []Message {
+func generateUserSubUpdateTestBatch(cnt int) []Message {
 	var batch []Message
 	for i := range cnt {
 		batch = append(batch, Message{
@@ -183,8 +432,11 @@ func generateUserSubUpdateTestBatchMessages(cnt int) []Message {
 	return batch
 }
 
-func testSubscriptionUpdateHandler(failCnt int, rateLimitCnt int) *subscriptionUpdateHandler {
-	transport := NewFakeTransport(failCnt, rateLimitCnt)
+func generateUserSubUpdateTestOne() Message {
+	return generateUserSubUpdateTestBatch(1)[0]
+}
+
+func testSubscriptionUpdateHandler(transport http.RoundTripper) *subscriptionUpdateHandler {
 	httpClient := http.Client{}
 	httpClient.Transport = transport
 	lists := api.NewUsersApi("test", &httpClient, &logger.Noop{}, &rate.NoopLimiter{})

--- a/batch/user_update.go
+++ b/batch/user_update.go
@@ -1,7 +1,7 @@
 package batch
 
 import (
-	"net/http"
+	"errors"
 
 	"github.com/block/iterable-go/api"
 	iterable_errors "github.com/block/iterable-go/errors"
@@ -49,89 +49,95 @@ func (s *userUpdateHandler) SetCreateNewFields(createNewFields bool) *userUpdate
 	return s
 }
 
-func (s *userUpdateHandler) ProcessBatch(batch []Message) ([]Response, error, bool) {
-	batchReq, responses := s.generatePayloads(batch, s.CreateNewFields)
+func (s *userUpdateHandler) ProcessBatch(batch []Message) (ProcessBatchResponse, error) {
+	req, cannotRetry := s.generatePayloads(batch, s.CreateNewFields)
 
-	res, err := s.Client.BulkUpdate(batchReq.batch)
+	var result []Response
+	result = append(result, cannotRetry...)
+	if len(req.batch.Users) == 0 {
+		if len(cannotRetry) != 0 {
+			return StatusCannotRetry{result}, nil
+		}
+		return StatusSuccess{result}, nil
+	}
+
+	res, err := s.Client.BulkUpdate(req.batch)
 	s.logger.Debugf("BulkUpdateRequest response: %+v, err: %+v", res, err)
 	// Check for failures and add to responses
 	if err != nil {
-		apiErr := err.(*iterable_errors.ApiError)
-		if apiErr == nil {
-			return nil, err, shouldRetry(err)
+		var apiErr *iterable_errors.ApiError
+		if !errors.As(err, &apiErr) || apiErr == nil {
+			return nil, err
 		}
-		// If there is a validation error, send all messages individually
-		if apiErr.IterableCode == FieldTypeMismatchErr {
-			responses = addReqFailuresToResponses(batchReq.reqByEmailMap, responses, FieldTypeMismatchErr, true)
-			responses = addReqFailuresToResponses(batchReq.reqByUserIdMap, responses, FieldTypeMismatchErr, true)
-			return responses, nil, true
-		}
-		if apiErr.HttpStatusCode == http.StatusRequestTimeout {
-			errText := http.StatusText(http.StatusRequestTimeout)
-			responses = addReqFailuresToResponses(batchReq.reqByEmailMap, responses, errText, true)
-			responses = addReqFailuresToResponses(batchReq.reqByUserIdMap, responses, errText, true)
-			return responses, nil, true
-		}
-		if apiErr.HttpStatusCode == http.StatusRequestEntityTooLarge {
-			errText := http.StatusText(http.StatusRequestEntityTooLarge)
-			responses = addReqFailuresToResponses(batchReq.reqByEmailMap, responses, errText, true)
-			responses = addReqFailuresToResponses(batchReq.reqByUserIdMap, responses, errText, true)
-			return responses, nil, true
-		}
-		return nil, err, shouldRetry(err)
-	} else {
-		// Map email/userId failures back to requests
-		responses = parseReqFailures(res.FailedUpdates.ConflictEmails, batchReq.reqByEmailMap, responses, ConflictEmailsErr)
-		responses = parseReqFailures(res.FailedUpdates.ConflictUserIds, batchReq.reqByUserIdMap, responses, ConflictUserIdsErr)
-		responses = parseReqFailures(res.FailedUpdates.ForgottenEmails, batchReq.reqByEmailMap, responses, ForgottenEmailsErr)
-		responses = parseReqFailures(res.FailedUpdates.ForgottenUserIds, batchReq.reqByUserIdMap, responses, ForgottenUserIdsErr)
-		responses = parseReqFailures(res.FailedUpdates.InvalidDataEmails, batchReq.reqByEmailMap, responses, InvalidDataEmailsErr)
-		responses = parseReqFailures(res.FailedUpdates.InvalidDataUserIds, batchReq.reqByUserIdMap, responses, InvalidDataUserIdsErr)
-		responses = parseReqFailures(res.FailedUpdates.InvalidEmails, batchReq.reqByEmailMap, responses, InvalidEmailsErr)
-		responses = parseReqFailures(res.FailedUpdates.InvalidUserIds, batchReq.reqByUserIdMap, responses, InvalidUserIdsErr)
-		responses = parseReqFailures(res.FailedUpdates.NotFoundEmails, batchReq.reqByEmailMap, responses, NotFoundEmailsErr)
-		responses = parseReqFailures(res.FailedUpdates.NotFoundUserIds, batchReq.reqByUserIdMap, responses, NotFoundUserIdsErr)
 
-		// Add success to remaining requests
-		responses = addReqSuccessToResponses(batchReq.reqByEmailMap, responses)
-		responses = addReqSuccessToResponses(batchReq.reqByUserIdMap, responses)
+		messages := flatValues(req.reqByEmailMap, req.reqByUserIdMap)
+
+		// If there is a validation error, send all messages individually
+		if apiErr.IterableCode == iterable_errors.ITERABLE_FieldTypeMismatchErrStr {
+			err2 := errors.Join(ErrFieldTypeMismatch, err)
+			result = append(result, toFailures(messages, err2, true)...)
+
+			return StatusRetryIndividual{result}, nil
+		}
+
+		return handleBatchError(apiErr, cannotRetry, messages)
 	}
 
-	return responses, nil, false
+	var sentAndFailed []Response
+	f := res.FailedUpdates
+	// Map email/userId failures back to requests
+	sentAndFailed = append(sentAndFailed, parseFailures(f.ConflictEmails, req.reqByEmailMap, ErrConflictEmails)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.ConflictUserIds, req.reqByUserIdMap, ErrConflictUserIds)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.ForgottenEmails, req.reqByEmailMap, ErrForgottenEmails)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.ForgottenUserIds, req.reqByUserIdMap, ErrForgottenUserIds)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidDataEmails, req.reqByEmailMap, ErrInvalidDataEmails)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidDataUserIds, req.reqByUserIdMap, ErrInvalidDataUserIds)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidEmails, req.reqByEmailMap, ErrInvalidEmails)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.InvalidUserIds, req.reqByUserIdMap, ErrInvalidUserIds)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.NotFoundEmails, req.reqByEmailMap, ErrNotFoundEmails)...)
+	sentAndFailed = append(sentAndFailed, parseFailures(f.NotFoundUserIds, req.reqByUserIdMap, ErrNotFoundUserIds)...)
+
+	result = append(result, sentAndFailed...)
+	result = append(result, toSuccess(req.reqByEmailMap)...)
+	result = append(result, toSuccess(req.reqByUserIdMap)...)
+
+	if len(cannotRetry) == 0 && len(sentAndFailed) == 0 {
+		return StatusSuccess{result}, nil
+	}
+	return StatusPartialSuccess{result}, nil
 }
 
 func (s *userUpdateHandler) ProcessOne(req Message) Response {
-	s.logger.Debugf("UserRequest - ProccessOne request on retry")
-
 	var res Response
-	if subData, ok := req.Data.(*types.BulkUpdateUser); ok {
+	if data, ok := req.Data.(*types.BulkUpdateUser); ok {
 		// Transform BulkUpdateUser to UserRequest
 		_, err := s.Client.UpdateOrCreate(types.UserRequest{
-			Email:              subData.Email,
-			UserId:             subData.UserId,
-			DataFields:         subData.DataFields,
-			PreferUserId:       subData.PreferUserId,
-			MergeNestedObjects: subData.MergeNestedObjects,
+			Email:              data.Email,
+			UserId:             data.UserId,
+			DataFields:         data.DataFields,
+			PreferUserId:       data.PreferUserId,
+			MergeNestedObjects: data.MergeNestedObjects,
 			CreateNewFields:    s.CreateNewFields,
 		})
 		if err != nil {
-			s.logger.Debugf("Failed to process UserRequest: %v", err)
+			s.logger.Debugf("Failed to process UserUpdate/ProcessOne: %v", err)
 		}
 
 		res = Response{
 			OriginalReq: req,
 			Error:       err,
-			Retry:       shouldRetry(err),
+			Retry:       oneCanRetry(err),
 		}
 	} else {
-		s.logger.Errorf("Invalid data type in UserUpdate batch request")
+		s.logger.Errorf("Invalid data type in UserUpdate/ProcessOne: %t", req.Data)
 		res = Response{
 			OriginalReq: req,
-			Error:       InvalidDataErr,
+			Error: errors.Join(
+				ErrInvalidDataType,
+				ErrClientValidationApiErr,
+			),
 		}
 	}
-
-	s.logger.Debugf("Successfully sent UserRequest in ProcessOne")
 
 	return res
 }
@@ -140,24 +146,26 @@ func (s *userUpdateHandler) generatePayloads(
 	messages []Message,
 	createNewFields *bool,
 ) (*userUpdateBatch, []Response) {
-	var responses []Response
+	var cannotRetry []Response
 	newBatch := newUserUpdateBatch(createNewFields)
 	for _, req := range messages {
-		if subData, ok := req.Data.(*types.BulkUpdateUser); ok {
-			if subData.Email != "" {
-				addReqToMap(newBatch.reqByEmailMap, req, subData.Email)
+		if data, ok := req.Data.(*types.BulkUpdateUser); ok {
+			if data.Email != "" {
+				addReqToMap(newBatch.reqByEmailMap, req, data.Email)
 			} else {
-				addReqToMap(newBatch.reqByUserIdMap, req, subData.UserId)
+				addReqToMap(newBatch.reqByUserIdMap, req, data.UserId)
 			}
-			newBatch.batch.Users = append(newBatch.batch.Users, *subData)
+			newBatch.batch.Users = append(newBatch.batch.Users, *data)
 		} else {
-			s.logger.Errorf("Invalid data type in UserUpdate batch request")
-			responses = append(responses, Response{
-				OriginalReq: req,
-				Error:       InvalidDataErr,
-			})
+			s.logger.Errorf("Invalid data type in UserUpdate/ProcessBatch: %t", req.Data)
+			m := toFailure(
+				req,
+				errors.Join(ErrInvalidDataType, ErrClientValidationApiErr),
+				false,
+			)
+			cannotRetry = append(cannotRetry, m)
 		}
 	}
 
-	return newBatch, responses
+	return newBatch, cannotRetry
 }

--- a/batch/user_update_test.go
+++ b/batch/user_update_test.go
@@ -1,85 +1,382 @@
 package batch
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"testing"
 
 	"github.com/block/iterable-go/api"
+	iterable_errors "github.com/block/iterable-go/errors"
 	"github.com/block/iterable-go/logger"
 	"github.com/block/iterable-go/rate"
 	"github.com/block/iterable-go/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUserUpdateBatchHandler_ProcessBatch(t *testing.T) {
 	tests := []struct {
-		name               string
-		failCnt            int
-		rateLimitCnt       int
-		contentTooLargeCnt int
-		expectedErr        bool
-		expectedRetry      bool
-		expectedResLen     int
+		name             string
+		batchSize        int
+		invalidSize      int
+		resStatusCode    int
+		resBody          []byte
+		expectApiCalls   int
+		expectErr        bool
+		expectStatus     ProcessBatchResponse
+		expectMsgNoRetry int
+		expectMsgRetry   int
+		expectMsgError   int
+		expectMsgNoError int
 	}{
 		{
-			name:               "Success",
-			failCnt:            0,
-			rateLimitCnt:       0,
-			contentTooLargeCnt: 0,
-			expectedErr:        false,
-			expectedRetry:      false,
-			expectedResLen:     10,
+			name:             "Empty",
+			batchSize:        0,
+			resStatusCode:    200,
+			expectApiCalls:   0,
+			expectErr:        false,
+			expectStatus:     StatusSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   0,
+			expectMsgError:   0,
+			expectMsgNoError: 0,
 		},
 		{
-			name:               "Fail",
-			failCnt:            1,
-			rateLimitCnt:       0,
-			contentTooLargeCnt: 0,
-			expectedErr:        true,
-			expectedRetry:      true,
-			expectedResLen:     0,
+			name:             "Success",
+			batchSize:        10,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":10}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusSuccess{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   0,
+			expectMsgError:   0,
+			expectMsgNoError: 10,
 		},
 		{
-			name:               "RateLimit",
-			failCnt:            0,
-			rateLimitCnt:       1,
-			contentTooLargeCnt: 0,
-			expectedErr:        true,
-			expectedRetry:      true,
-			expectedResLen:     0,
+			name:             "Batch Request: 500",
+			batchSize:        10,
+			resStatusCode:    500,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryBatch{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
 		},
 		{
-			name:               "ContentTooLarge",
-			failCnt:            0,
-			rateLimitCnt:       0,
-			contentTooLargeCnt: 1,
-			expectedErr:        false,
-			expectedRetry:      true,
-			expectedResLen:     10,
+			name:             "Batch Request: RateLimit",
+			batchSize:        10,
+			resStatusCode:    429,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryBatch{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: ContentTooLarge",
+			batchSize:        10,
+			resStatusCode:    413,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Conflict",
+			batchSize:        10,
+			resStatusCode:    409,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Request Timeout",
+			batchSize:        10,
+			resStatusCode:    408,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: Forbidden",
+			batchSize:        10,
+			resStatusCode:    403,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 400",
+			batchSize:        10,
+			resStatusCode:    400,
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 10,
+			expectMsgRetry:   0,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 400 + RequestFieldsTypesMismatched",
+			batchSize:        10,
+			resStatusCode:    400,
+			resBody:          []byte(`{"code":"RequestFieldsTypesMismatched"}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusRetryIndividual{},
+			expectMsgNoRetry: 0,
+			expectMsgRetry:   10,
+			expectMsgError:   10,
+			expectMsgNoError: 0,
+		},
+		{
+			name:             "Batch Request: 200 + invalid messages",
+			batchSize:        10,
+			invalidSize:      5,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":10}`),
+			expectApiCalls:   1,
+			expectErr:        false,
+			expectStatus:     StatusPartialSuccess{},
+			expectMsgNoRetry: 5,
+			expectMsgRetry:   0,
+			expectMsgError:   5,
+			expectMsgNoError: 10,
+		},
+		{
+			name:             "all messages are invalid",
+			invalidSize:      5,
+			resStatusCode:    200,
+			resBody:          []byte(`{"successCount":5}`), // never called
+			expectApiCalls:   0,
+			expectErr:        false,
+			expectStatus:     StatusCannotRetry{},
+			expectMsgNoRetry: 5,
+			expectMsgRetry:   0,
+			expectMsgError:   5,
+			expectMsgNoError: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := testUserUpdateHandler(tt.failCnt, tt.rateLimitCnt, tt.contentTooLargeCnt)
-			batch := generateUserUpdateTestBatchMessages(10)
-			res, err, retry := handler.ProcessBatch(batch)
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testUserUpdateHandler(transport)
+			batch := generateUserUpdateTestBatch(tt.batchSize)
+			for range tt.invalidSize {
+				batch = append(batch, Message{
+					Data: "invalid",
+				})
+			}
 
-			if tt.expectedErr {
+			res, err := handler.ProcessBatch(batch)
+
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			if tt.expectErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tt.expectedResLen, len(res))
-			assert.Equal(t, tt.expectedRetry, retry)
+
+			if tt.expectStatus != nil {
+				assert.IsType(t, tt.expectStatus, res)
+			}
+
+			msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res.response())
+
+			assert.Equal(t, tt.expectMsgRetry, msgRetry)
+			assert.Equal(t, tt.expectMsgNoRetry, msgNoRetry)
+			assert.Equal(t, tt.expectMsgError, msgErr)
+			assert.Equal(t, tt.expectMsgNoError, msgNoErr)
 		})
 	}
 }
 
-func generateUserUpdateTestBatchMessages(cnt int) []Message {
+func TestUserUpdateBatchHandler_ProcessBatch_PartialSuccess(t *testing.T) {
+	res := types.BulkUpdateResponse{
+		FailedUpdates: types.FailedUpdates{
+			ConflictEmails:     []string{"email1@example.com"},
+			ConflictUserIds:    []string{"email1"},
+			ForgottenEmails:    []string{"email2@example.com"},
+			ForgottenUserIds:   []string{"email2"},
+			InvalidDataEmails:  []string{"email3@example.com"},
+			InvalidDataUserIds: []string{"email3"},
+			InvalidEmails:      []string{"email4@example.com"},
+			InvalidUserIds:     []string{"email4"},
+			NotFoundEmails:     []string{"email5@example.com"},
+			NotFoundUserIds:    []string{"email5"},
+		},
+	}
+	data, _ := json.Marshal(res)
+	req := []Message{
+		{Data: "invalid"},
+		{Data: &types.BulkUpdateUser{Email: "email1@example.com"}},
+		{Data: &types.BulkUpdateUser{UserId: "email1"}},
+		{Data: &types.BulkUpdateUser{Email: "email2@example.com"}},
+		{Data: &types.BulkUpdateUser{UserId: "email2"}},
+		{Data: &types.BulkUpdateUser{Email: "email3@example.com"}},
+		{Data: &types.BulkUpdateUser{UserId: "email3"}},
+		{Data: &types.BulkUpdateUser{Email: "email4@example.com"}},
+		{Data: &types.BulkUpdateUser{UserId: "email4"}},
+		{Data: &types.BulkUpdateUser{Email: "email5@example.com"}},
+		{Data: &types.BulkUpdateUser{UserId: "email5"}},
+		// Successful
+		{Data: &types.BulkUpdateUser{Email: "email6@example.com"}},
+		{Data: &types.BulkUpdateUser{UserId: "email6"}},
+	}
+
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, data)
+	handler := testUserUpdateHandler(transport)
+	res2, err := handler.ProcessBatch(req)
+
+	assert.Equal(t, 1, transport.reqCnt)
+	assert.NoError(t, err)
+	assert.IsType(t, StatusPartialSuccess{}, res2)
+	assert.Equal(t, len(req), len(res2.response()))
+
+	msgNoRetry, msgRetry, msgNoErr, msgErr := countResponses(t, res2.response())
+
+	assert.Equal(t, 0, msgRetry)
+	assert.Equal(t, 11, msgNoRetry)
+	assert.Equal(t, 11, msgErr)
+	assert.Equal(t, 2, msgNoErr)
+}
+
+func TestUserUpdateBatchHandler_ProcessOne(t *testing.T) {
+	tests := []struct {
+		name           string
+		resStatusCode  int
+		resBody        []byte
+		expectApiCalls int
+		expectErr      bool
+		expectRetry    bool
+	}{
+		{
+			name:           "Success",
+			resStatusCode:  200,
+			resBody:        []byte(`{"code":"200"}`),
+			expectApiCalls: 1,
+		},
+		{
+			name:           "status:0",
+			resStatusCode:  0,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:500",
+			resStatusCode:  500,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:408",
+			resStatusCode:  408,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:429",
+			resStatusCode:  408,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    true,
+		},
+		{
+			name:           "status:409",
+			resStatusCode:  409,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    false,
+		},
+		{
+			name:           "status:400",
+			resStatusCode:  400,
+			resBody:        []byte(`{}`),
+			expectApiCalls: 1,
+			expectErr:      true,
+			expectRetry:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testUserUpdateHandler(transport)
+
+			req := generateUserUpdateTestOne()
+			res := handler.ProcessOne(req)
+
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			if tt.expectErr {
+				assert.Error(t, res.Error)
+				assert.Equal(t, tt.expectRetry, res.Retry)
+			} else {
+				assert.NoError(t, res.Error)
+				assert.False(t, res.Retry)
+			}
+		})
+	}
+}
+
+func TestUserUpdateBatchHandler_ProcessOne_InvalidData(t *testing.T) {
+	transport := NewFakeTransport(0, 0)
+	transport.AddResponseQueue(200, []byte(`{}`))
+	handler := testUserUpdateHandler(transport)
+	req := Message{
+		Data: "invalid",
+	}
+	res := handler.ProcessOne(req)
+
+	assert.Equal(t, 0, transport.reqCnt)
+	assert.Error(t, res.Error)
+	assert.ErrorIs(t, res.Error, ErrInvalidDataType)
+	assert.ErrorIs(t, res.Error, ErrClientValidationApiErr)
+	var apiErr *iterable_errors.ApiError
+	ok := errors.As(res.Error, &apiErr)
+	require.True(t, ok)
+	assert.Equal(t, 400, apiErr.HttpStatusCode)
+	assert.False(t, res.Retry)
+}
+
+func generateUserUpdateTestBatch(size int) []Message {
 	var batch []Message
-	for i := range cnt {
+	for i := range size {
 		batch = append(batch, Message{
 			Data: &types.BulkUpdateUser{
 				Email:      "test" + strconv.Itoa(i) + "@test.com",
@@ -92,12 +389,35 @@ func generateUserUpdateTestBatchMessages(cnt int) []Message {
 	return batch
 }
 
-func testUserUpdateHandler(failCnt int, rateLimitCnt int, contentTooLargeCnt int) *userUpdateHandler {
-	transport := NewFakeTransport(failCnt, rateLimitCnt)
-	transport.SetContentTooLargeCount(contentTooLargeCnt)
+func generateUserUpdateTestOne() Message {
+	return generateUserUpdateTestBatch(1)[0]
+}
+
+func testUserUpdateHandler(transport http.RoundTripper) *userUpdateHandler {
 	httpClient := http.Client{}
 	httpClient.Transport = transport
-	lists := api.NewUsersApi("test", &httpClient, &logger.Noop{}, &rate.NoopLimiter{})
-	handler := NewUserUpdateHandler(lists, &logger.Noop{})
+	users := api.NewUsersApi("test", &httpClient, &logger.Noop{}, &rate.NoopLimiter{})
+	handler := NewUserUpdateHandler(users, &logger.Noop{})
 	return handler.(*userUpdateHandler)
+}
+
+func countResponses(t *testing.T, res []Response) (int, int, int, int) {
+	msgNoRetry := 0
+	msgRetry := 0
+	msgErr := 0
+	msgNoErr := 0
+	for _, r := range res {
+		if r.Error != nil {
+			msgErr++
+			if r.Retry {
+				msgRetry++
+			} else {
+				msgNoRetry++
+			}
+		} else {
+			msgNoErr++
+		}
+		assert.NotNil(t, r.OriginalReq)
+	}
+	return msgNoRetry, msgRetry, msgNoErr, msgErr
 }

--- a/batch/utils.go
+++ b/batch/utils.go
@@ -2,45 +2,19 @@ package batch
 
 import (
 	"errors"
+	"maps"
 
 	iterable_errors "github.com/block/iterable-go/errors"
+	"github.com/block/iterable-go/types"
 )
 
-const (
-	ConflictEmailsErr     = "Email conflicts"
-	ConflictUserIdsErr    = "UserId conflicts"
-	ForgottenEmailsErr    = "Email Forgotten"
-	ForgottenUserIdsErr   = "UserId Forgotten"
-	InvalidDataEmailsErr  = "Invalid Data"
-	InvalidDataUserIdsErr = InvalidDataEmailsErr
-	InvalidEmailsErr      = "Malformed Email"
-	InvalidUserIdsErr     = "Malformed UserId"
-	NotFoundEmailsErr     = "Email not found"
-	NotFoundUserIdsErr    = "UserId not found"
-	ValidEmailFailures    = "Internal Error with Email"
-	ValidUserIdFailures   = "Internal Error with UserId"
-
-	InvalidDataTypeErrStr = "Invalid data type in batch request"
-	InvalidListId         = "List ID not valid for Iterable project"
-	UnknownError          = "Subscribe request failed with unknown error"
-)
-
-var (
-	InvalidDataErr = &iterable_errors.ApiError{
-		Stage:          iterable_errors.STAGE_BEFORE_REQUEST,
-		Type:           iterable_errors.TYPE_INVALID_DATA,
-		HttpStatusCode: 500,
-		IterableCode:   InvalidDataTypeErrStr,
-	}
-)
-
-// Add request to map of requests
 func addReqToMap(reqMap map[string][]Message, req Message, key string) {
 	r := reqMap[key]
 	reqMap[key] = append(r, req)
 }
 
-func addReqSuccessToResponses(reqMap map[string][]Message, responses []Response) []Response {
+func toSuccess(reqMap map[string][]Message) []Response {
+	var responses []Response
 	for _, reqSlice := range reqMap {
 		for _, req := range reqSlice {
 			responses = append(responses, Response{
@@ -51,21 +25,32 @@ func addReqSuccessToResponses(reqMap map[string][]Message, responses []Response)
 	return responses
 }
 
-func addReqFailuresToResponses(reqMap map[string][]Message, responses []Response, err string, retry bool) []Response {
-	respErr := errors.New(err)
-	for _, reqSlice := range reqMap {
-		for _, req := range reqSlice {
-			responses = append(responses, Response{
-				OriginalReq: req,
-				Error:       respErr,
-				Retry:       retry,
-			})
-		}
+func toFailures(
+	messages []Message,
+	err error,
+	retry bool,
+) []Response {
+	var responses []Response
+	for _, m := range messages {
+		responses = append(responses, toFailure(m, err, retry))
 	}
 	return responses
 }
 
-func parseReqFailures(failedKeys []string, reqMap map[string][]Message, responses []Response, err string) []Response {
+func toFailure(
+	m Message,
+	err error,
+	retry bool,
+) Response {
+	return Response{
+		OriginalReq: m,
+		Error:       err,
+		Retry:       retry,
+	}
+}
+
+func parseFailures(failedKeys []string, reqMap map[string][]Message, err error) []Response {
+	var responses []Response
 	if len(failedKeys) == 0 {
 		return responses
 	}
@@ -85,7 +70,7 @@ func parseReqFailures(failedKeys []string, reqMap map[string][]Message, response
 				// Set Retry to true so the batch processor will send the messages individually
 				responses = append(responses, Response{
 					OriginalReq: req,
-					Error:       errors.New(err),
+					Error:       err,
 					Retry:       retry,
 				})
 			}
@@ -95,14 +80,118 @@ func parseReqFailures(failedKeys []string, reqMap map[string][]Message, response
 	return responses
 }
 
-func shouldRetry(err error) bool {
-	if err != nil {
-		if apiErr, ok := err.(*iterable_errors.ApiError); ok {
-			status := apiErr.HttpStatusCode
-			return status == 0 || // Request was not sent or context timed out
-				status == 429 || // Deadline exceeded or rate limited
-				status >= 500 // Any server error
+func parseDisallowedEventNames(
+	disallowedEventNames []string,
+	reqMap map[string][]Message,
+) []Response {
+	var responses []Response
+	if len(disallowedEventNames) == 0 {
+		return responses
+	}
+
+	// Make a map of disallowed event names for faster lookup
+	disallowedEventNameMap := make(map[string]bool)
+	for _, name := range disallowedEventNames {
+		disallowedEventNameMap[name] = true
+	}
+
+	for reqKey, reqSlice := range reqMap {
+		var newReqSlice []Message
+		for _, req := range reqSlice {
+			trackReq, ok := req.Data.(*types.EventTrackRequest)
+			if ok {
+				_, found := disallowedEventNameMap[trackReq.EventName]
+				if found {
+					responses = append(responses, Response{
+						OriginalReq: req,
+						Error: errors.Join(
+							ErrDisallowedEventName,
+							ErrServerValidationApiErr,
+						),
+					})
+					continue
+				}
+			}
+			newReqSlice = append(newReqSlice, req)
+		}
+		reqMap[reqKey] = newReqSlice
+	}
+	return responses
+}
+
+// batchCanRetryBatch determines if a batch operation can be retried as a whole based on the error type.
+// Returns true for network-related failures (status 0), rate limits (status 429), and server errors (status 500+).
+// These are typically transient issues where retrying the entire batch might succeed.
+func batchCanRetryBatch(err error) bool {
+	var apiErr *iterable_errors.ApiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	status := apiErr.HttpStatusCode
+	return status == 0 || // Request was not sent or context timed out
+		status == 429 || // Deadline exceeded or rate limited
+		status >= 500 // Any server error
+}
+
+// batchCanRetryOne determines if individual requests from a failed batch should be retried separately.
+func batchCanRetryOne(err error) bool {
+	var apiErr *iterable_errors.ApiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	status := apiErr.HttpStatusCode
+	return status == 0 || // Request was not sent or context timed out
+		status == 408 || // Client Request Timeout
+		status == 409 || // Conflict
+		status == 413 || // (batch request) Payload Too Large
+		status == 429 || // Deadline exceeded or rate limited
+		status >= 500 // Any server error
+}
+
+// oneCanRetry determines if a single request operation should be retried.
+func oneCanRetry(err error) bool {
+	var apiErr *iterable_errors.ApiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	status := apiErr.HttpStatusCode
+	return status == 0 || // Request was not sent or context timed out
+		status == 408 || // Client Request Timeout
+		status == 429 || // Deadline exceeded or rate limited
+		status >= 500 // Any server error
+}
+
+func handleBatchError(
+	apiErr *iterable_errors.ApiError,
+	cannotRetry []Response,
+	messagesSent []Message,
+) (ProcessBatchResponse, error) {
+	var result []Response
+	result = append(result, cannotRetry...)
+
+	if batchCanRetryBatch(apiErr) {
+		result = append(result, toFailures(messagesSent, apiErr, true)...)
+		return StatusRetryBatch{result, apiErr}, nil
+	} else if batchCanRetryOne(apiErr) {
+		result = append(result, toFailures(messagesSent, apiErr, true)...)
+		return StatusRetryIndividual{result}, nil
+	}
+
+	result = append(result, toFailures(messagesSent, apiErr, false)...)
+	return StatusCannotRetry{result}, nil
+}
+
+func flatValues(inMaps ...map[string][]Message) []Message {
+	var res []Message
+
+	for _, m := range inMaps {
+		for mValues := range maps.Values(m) {
+			res = append(res, mValues...)
 		}
 	}
-	return false
+
+	return res
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,9 +15,10 @@ const (
 	TYPE_HTTP_STATUS     = "not-ok-http-status"
 	TYPE_INVALID_DATA    = "invalid-data"
 
-	ITERABLE_NoUserWithIdExists = "error.users.noUserWithIdExists"
-	ITERABLE_InvalidList        = "error.lists.invalidListId"
-	ITERABLE_Success            = "Success"
+	ITERABLE_NoUserWithIdExists      = "error.users.noUserWithIdExists"
+	ITERABLE_InvalidList             = "error.lists.invalidListId"
+	ITERABLE_Success                 = "Success"
+	ITERABLE_FieldTypeMismatchErrStr = "RequestFieldsTypesMismatched"
 )
 
 type ApiError struct {


### PR DESCRIPTION
### Motivation

(Before this change)

Batch module consists of 2 major pieces
* `Processor` - is a generic wrapper that makes batches from incoming single messages, sends them to `Handler`(s) and handles the responses.
* `Handler` - there are multiple handlers - `event_track`, `subscription_update` and others. `Handler` implements 2 methods `ProcessBatch([]Message)` and `ProcessOne(Message)`. `Handler` knows how to send requests to a specific Iterable API.

There are multiple issues with the current setups:

#### One

`ProcessBatch` method returns  3 values:
* `[]Response` - when messages are handled, they are wrapped into a `Response` and sent back
* `error` - when something fails
* `bool` - True if we need to tell the caller (`Processor`) to retry.

Each `Response` has `Error` and `Retry` fields.

This setup makes it inconsistent and confusing for the caller.
* What happens when `ProcessBatch` returns `True` for retry, but individual responses have `Retry=false`?
* What happens if `ProcessBatch` returns not-nil `error` and **some** individual responses  have `Retry=true` - should we retry batch or one?
* and many more.

Additionally, Iterable APIs are not consistent about what they return - sometimes an API responds with an http error with a body, sometimes it's a 200 with errors in the body, etc.

To support all this, `Processor` needs to return "fake" http response codes to the customer and that's not great for observability.

#### Two

Errors are inconsistent and scattered across many files in the `batch` module. This makes it tricky to find the right error and understand what caused it.

Additionally, request errors (ApiError) are replaced with a different error. This makes it impossible to find the actual response code we got from Iterable API. Not great for observability and for debugging.

### The change

To fix the shortcomings, this change changes the `ProcessBatch` interface to return `(ProcessBatchResponse, error)`. The `ProcessBatchResponse` is akin algebraic data type and to understand what's inside the actual batch response - we need to find its type:

```
res, err := p.handler.ProcessBatch(batchReq)
if err != nil {
  return err
}

switch status := batchRes.(type) {
case StatusRetryBatch:
  // retry Batch request
case StatusCannotRetry:
  // cannot retry
case StatusSuccess:
  // all successful
case StatusPartialSuccess:
  // batch request was successful, but some messages have errors
case StatusRetryIndividual:
  // batch request failed, but individual requests might be successful
}
```

This is a much cleaner approach that'll help us to support the existing Handlers and add new ones.

All errors have been moved to `batch_errors.go`. All specific `Handler`s have been re-worked to return joined error plus the batch ApiError where possible - this way we can look inside the actual request to understand what happened.


### How to Adopt

If you use `Response.Error` field to make decisions if a message was processed successfully (or needs to be retried), then you'll have to change that.

Instead casting an error, use `errors.As`
Example:
```
// before
if apiErr, ok := res.Error.(*errors.ApiError); ok {}

// after 
var apiErr *errors.ApiError
if ok := errors.As(res.Error); ok {}
```

Instead of using `.Error()` as a string, use `errors.Is`
Example:
```
// before
if res.Error.Error() == "Disallowed Event Name" {}

// after
if errors.Is(res.Error, batch.ErrDisallowedEventName) {}
```

