### PR TITLE
Adds ErrFieldTypeMismatchType

### DIFF
--- a/batch/event_track.go
+++ b/batch/event_track.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/parsers"
 
 	"github.com/block/iterable-go/api"
 	iterable_errors "github.com/block/iterable-go/errors"
@@ -65,7 +66,8 @@ func (s *eventTrackHandler) ProcessBatch(batch []Message) (ProcessBatchResponse,
 
 		// If there is a validation error, send all messages individually
 		if apiErr.IterableCode == iterable_errors.ITERABLE_FieldTypeMismatchErrStr {
-			err2 := errors.Join(ErrFieldTypeMismatch, err)
+			fields, _ := parsers.MismatchedFieldsParamsFromResponseBody(apiErr.Body)
+			err2 := errors.Join(newErrFieldTypeMismatch(fields), err)
 			result = append(result, toFailures(messages, err2, true)...)
 
 			return StatusRetryIndividual{result}, nil

--- a/batch/event_track_test.go
+++ b/batch/event_track_test.go
@@ -370,6 +370,142 @@ func TestEventTrackBatchHandler_ProcessBatch_DisallowedEventNames(t *testing.T) 
 	}
 }
 
+func TestEventTrackBatchHandler_ProcessBatch_FieldTypeMismatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		batchSize      int
+		resStatusCode  int
+		resBody        []byte
+		expectApiCalls int
+		expectStatus   ProcessBatchResponse
+		expectFields   types.MismatchedFieldsParams
+	}{
+		{
+			name:           "400 with empty validationErrors",
+			batchSize:      1,
+			resStatusCode:  400,
+			resBody:        []byte(`{"code":"RequestFieldsTypesMismatched"}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields:   types.MismatchedFieldsParams{},
+		},
+		{
+			name:           "500 with empty validationErrors",
+			batchSize:      1,
+			resStatusCode:  500,
+			resBody:        []byte(`{"code":"RequestFieldsTypesMismatched"}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields:   types.MismatchedFieldsParams{},
+		},
+		{
+			name:          "400 with non-empty validationErrors",
+			batchSize:     1,
+			resStatusCode: 400,
+			resBody: []byte(`{
+				"code":"RequestFieldsTypesMismatched",
+				"msg": "boo",
+				"params": {
+					"validationErrors": {
+						"my_project_etl:::soc_signup_at": {
+							"incomingTypes": ["string", "keyword"],
+							"expectedType": "date",
+							"category": "user",
+							"offendingValue": "2020-04-13 14:04:09.000",
+							"_type": "UnexpectedType"
+						}
+					}
+				}
+			}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields: types.MismatchedFieldsParams{
+				ValidationErrors: types.MismatchedFieldsErrors{
+					"my_project_etl:::soc_signup_at": types.MismatchedFieldError{
+						IncomingTypes:  []string{"string", "keyword"},
+						ExpectedType:   "date",
+						Category:       "user",
+						OffendingValue: "2020-04-13 14:04:09.000",
+						Type:           "UnexpectedType",
+					},
+				},
+			},
+		},
+		{
+			name:          "400 with non-empty validationErrors with extra fields",
+			batchSize:     1,
+			resStatusCode: 400,
+			resBody: []byte(`{
+				"code":"RequestFieldsTypesMismatched",
+				"msg": "boo",
+				"params": {
+					"unknown": 1,
+					"validationErrors": {
+						"my_project_etl:::soc_signup_at": {
+							"incomingTypes": ["string", "keyword"],
+							"expectedType": "date",
+							"unknown": 1,
+							"invalid": "a"
+						}
+					}
+				}
+			}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields: types.MismatchedFieldsParams{
+				ValidationErrors: types.MismatchedFieldsErrors{
+					"my_project_etl:::soc_signup_at": types.MismatchedFieldError{
+						IncomingTypes: []string{"string", "keyword"},
+						ExpectedType:  "date",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testEventTrackHandler(transport)
+			batch := generateEventTrackTestBatch(tt.batchSize)
+
+			res, err := handler.ProcessBatch(batch)
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			assert.NoError(t, err)
+
+			assert.IsType(t, tt.expectStatus, StatusRetryIndividual{})
+
+			for _, r := range res.response() {
+				assert.True(t, r.Retry)
+				assert.Error(t, r.Error)
+				assert.NotNil(t, r.OriginalReq)
+
+				allErr := Unwrap(r.Error)
+				assert.Equal(t, 2, len(allErr))
+
+				var err1 *ErrFieldTypeMismatchType
+				ok1 := errors.Is(r.Error, ErrFieldTypeMismatch)
+				ok2 := errors.As(r.Error, &err1)
+				assert.True(t, ok1)
+				assert.True(t, ok2)
+				assert.NotNil(t, err1)
+				ok := assert.ObjectsAreEqualValues(tt.expectFields, err1.MismatchedFields())
+				assert.True(t, ok)
+
+				var err2 *iterable_errors.ApiError
+				ok1 = errors.Is(r.Error, ErrApiError)
+				ok2 = errors.As(r.Error, &err2)
+				assert.True(t, ok1)
+				assert.True(t, ok2)
+				assert.NotNil(t, err2)
+				assert.Equal(t, tt.resStatusCode, err2.HttpStatusCode)
+
+			}
+		})
+	}
+}
+
 func TestEventTrackBatchHandler_ProcessBatch_DuplicateEvent(t *testing.T) {
 	batch := []Message{
 		{

--- a/batch/user_update.go
+++ b/batch/user_update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/block/iterable-go/api"
 	iterable_errors "github.com/block/iterable-go/errors"
 	"github.com/block/iterable-go/logger"
+	"github.com/block/iterable-go/parsers"
 	"github.com/block/iterable-go/types"
 )
 
@@ -74,7 +75,8 @@ func (s *userUpdateHandler) ProcessBatch(batch []Message) (ProcessBatchResponse,
 
 		// If there is a validation error, send all messages individually
 		if apiErr.IterableCode == iterable_errors.ITERABLE_FieldTypeMismatchErrStr {
-			err2 := errors.Join(ErrFieldTypeMismatch, err)
+			fields, _ := parsers.MismatchedFieldsParamsFromResponseBody(apiErr.Body)
+			err2 := errors.Join(newErrFieldTypeMismatch(fields), err)
 			result = append(result, toFailures(messages, err2, true)...)
 
 			return StatusRetryIndividual{result}, nil

--- a/batch/user_update_test.go
+++ b/batch/user_update_test.go
@@ -268,6 +268,142 @@ func TestUserUpdateBatchHandler_ProcessBatch_PartialSuccess(t *testing.T) {
 	assert.Equal(t, 2, msgNoErr)
 }
 
+func TestUserUpdateBatchHandler_ProcessBatch_FieldTypeMismatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		batchSize      int
+		resStatusCode  int
+		resBody        []byte
+		expectApiCalls int
+		expectStatus   ProcessBatchResponse
+		expectFields   types.MismatchedFieldsParams
+	}{
+		{
+			name:           "400 with empty validationErrors",
+			batchSize:      1,
+			resStatusCode:  400,
+			resBody:        []byte(`{"code":"RequestFieldsTypesMismatched"}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields:   types.MismatchedFieldsParams{},
+		},
+		{
+			name:           "500 with empty validationErrors",
+			batchSize:      1,
+			resStatusCode:  500,
+			resBody:        []byte(`{"code":"RequestFieldsTypesMismatched"}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields:   types.MismatchedFieldsParams{},
+		},
+		{
+			name:          "400 with non-empty validationErrors",
+			batchSize:     1,
+			resStatusCode: 400,
+			resBody: []byte(`{
+				"code":"RequestFieldsTypesMismatched",
+				"msg": "boo",
+				"params": {
+					"validationErrors": {
+						"my_project_etl:::soc_signup_at": {
+							"incomingTypes": ["string", "keyword"],
+							"expectedType": "date",
+							"category": "user",
+							"offendingValue": "2020-04-13 14:04:09.000",
+							"_type": "UnexpectedType"
+						}
+					}
+				}
+			}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields: types.MismatchedFieldsParams{
+				ValidationErrors: types.MismatchedFieldsErrors{
+					"my_project_etl:::soc_signup_at": types.MismatchedFieldError{
+						IncomingTypes:  []string{"string", "keyword"},
+						ExpectedType:   "date",
+						Category:       "user",
+						OffendingValue: "2020-04-13 14:04:09.000",
+						Type:           "UnexpectedType",
+					},
+				},
+			},
+		},
+		{
+			name:          "400 with non-empty validationErrors with extra fields",
+			batchSize:     1,
+			resStatusCode: 400,
+			resBody: []byte(`{
+				"code":"RequestFieldsTypesMismatched",
+				"msg": "boo",
+				"params": {
+					"unknown": 1,
+					"validationErrors": {
+						"my_project_etl:::soc_signup_at": {
+							"incomingTypes": ["string", "keyword"],
+							"expectedType": "date",
+							"unknown": 1,
+							"invalid": "a"
+						}
+					}
+				}
+			}`),
+			expectApiCalls: 1,
+			expectStatus:   StatusRetryIndividual{},
+			expectFields: types.MismatchedFieldsParams{
+				ValidationErrors: types.MismatchedFieldsErrors{
+					"my_project_etl:::soc_signup_at": types.MismatchedFieldError{
+						IncomingTypes: []string{"string", "keyword"},
+						ExpectedType:  "date",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewFakeTransport(0, 0)
+			transport.AddResponseQueue(tt.resStatusCode, tt.resBody)
+			handler := testUserUpdateHandler(transport)
+			batch := generateUserUpdateTestBatch(tt.batchSize)
+
+			res, err := handler.ProcessBatch(batch)
+			assert.Equal(t, tt.expectApiCalls, transport.reqCnt)
+			assert.NoError(t, err)
+
+			assert.IsType(t, tt.expectStatus, StatusRetryIndividual{})
+
+			for _, r := range res.response() {
+				assert.True(t, r.Retry)
+				assert.Error(t, r.Error)
+				assert.NotNil(t, r.OriginalReq)
+
+				allErr := Unwrap(r.Error)
+				assert.Equal(t, 2, len(allErr))
+
+				var err1 *ErrFieldTypeMismatchType
+				ok1 := errors.Is(r.Error, ErrFieldTypeMismatch)
+				ok2 := errors.As(r.Error, &err1)
+				assert.True(t, ok1)
+				assert.True(t, ok2)
+				assert.NotNil(t, err1)
+				ok := assert.ObjectsAreEqualValues(tt.expectFields, err1.MismatchedFields())
+				assert.True(t, ok)
+
+				var err2 *iterable_errors.ApiError
+				ok1 = errors.Is(r.Error, ErrApiError)
+				ok2 = errors.As(r.Error, &err2)
+				assert.True(t, ok1)
+				assert.True(t, ok2)
+				assert.NotNil(t, err2)
+				assert.Equal(t, tt.resStatusCode, err2.HttpStatusCode)
+
+			}
+		})
+	}
+}
+
 func TestUserUpdateBatchHandler_ProcessOne(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,9 @@
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	STAGE_BEFORE_REQUEST = "before-request"
@@ -44,4 +47,14 @@ func (e *ApiError) Error() string {
 		"http request to Iterable failed during '%s' stage with error type '%s', httpStatus: '%d'; original err: %v",
 		e.Stage, e.Type, e.HttpStatusCode, err,
 	)
+}
+
+// Is method is required by errors.Is() to properly distinguish between
+// different types -vs- same pointer to the same type.
+// Without it, errors.Is(err, ErrFieldTypeMismatch) returns false:
+// ok := errors.Is(errors.Join(&iterable_errors.ApiError{}), &iterable_errors.ApiError{})
+// ^ would be false
+func (e *ApiError) Is(other error) bool {
+	var err *ApiError
+	return errors.As(other, &err) && err != nil
 }


### PR DESCRIPTION
### Notes

This change introduces `batch.ErrFieldTypeMismatchType`.
The new type has `MismatchedFields()`.

This is useful for cases when a batch Handler (either `event_track` or `user_update`) receives this error from Iterable API and instead of sending an empty error back to the customer, the Handler parses the response body and extracts the mismatched fields.

Later, customers can check if the error type is valid and extract those fields from the error itself (instead of running extra steps to extract it from the join error).

Example:

Before:
```
if errors.Is(err, batch.ErrFieldTypeMismatch) {
  var apiErr *iterable_errors.ApiError
  ok = errors.As(err, &apiErr)
  if ok {
    res := types.PostResponse{}
    uErr := json.Unmarshal(apiErr.Body, &res)
    if uErr != nil {
      glog.Errorf("Error unmarshalling Mismatched Field response body: %v", uErr)
      return
    }
    mismatchedFields, ok := parsers.MismatchedFieldsParamsFromResponse(res)
    if ok {
      fmt.Println(mismatchedFields)
    }    
  }
}
```

After:
```
if (errors.Is(err, batch.ErrFieldTypeMismatch)) {
  var err1 *batch.ErrFieldTypeMismatchType
  ok := errors.As(r.Error, &err1)
  if ok {
    fmt.Println(err1.MismatchedFields())
  } 
}
```

### Tests
- new unit tests