### PR TITLE
Changes newErrFieldTypeMismatch -> NewErrFieldTypeMismatch

### DIFF
--- a/batch/batch_errors.go
+++ b/batch/batch_errors.go
@@ -118,7 +118,7 @@ func (e *ErrFieldTypeMismatchType) Is(other error) bool {
 
 var _ error = &ErrFieldTypeMismatchType{}
 
-func newErrFieldTypeMismatch(fields types.MismatchedFieldsParams) *ErrFieldTypeMismatchType {
+func NewErrFieldTypeMismatch(fields types.MismatchedFieldsParams) *ErrFieldTypeMismatchType {
 	return &ErrFieldTypeMismatchType{fields}
 }
 

--- a/batch/event_track.go
+++ b/batch/event_track.go
@@ -67,7 +67,7 @@ func (s *eventTrackHandler) ProcessBatch(batch []Message) (ProcessBatchResponse,
 		// If there is a validation error, send all messages individually
 		if apiErr.IterableCode == iterable_errors.ITERABLE_FieldTypeMismatchErrStr {
 			fields, _ := parsers.MismatchedFieldsParamsFromResponseBody(apiErr.Body)
-			err2 := errors.Join(newErrFieldTypeMismatch(fields), err)
+			err2 := errors.Join(NewErrFieldTypeMismatch(fields), err)
 			result = append(result, toFailures(messages, err2, true)...)
 
 			return StatusRetryIndividual{result}, nil

--- a/batch/user_update.go
+++ b/batch/user_update.go
@@ -76,7 +76,7 @@ func (s *userUpdateHandler) ProcessBatch(batch []Message) (ProcessBatchResponse,
 		// If there is a validation error, send all messages individually
 		if apiErr.IterableCode == iterable_errors.ITERABLE_FieldTypeMismatchErrStr {
 			fields, _ := parsers.MismatchedFieldsParamsFromResponseBody(apiErr.Body)
-			err2 := errors.Join(newErrFieldTypeMismatch(fields), err)
+			err2 := errors.Join(NewErrFieldTypeMismatch(fields), err)
 			result = append(result, toFailures(messages, err2, true)...)
 
 			return StatusRetryIndividual{result}, nil


### PR DESCRIPTION
### Notes

`newErrFieldTypeMismatch()` is a constructor for `*ErrFieldTypeMismatchType`.

Since the `ErrFieldTypeMismatchType` type has a field that's not public/exported:

```
type ErrFieldTypeMismatchType struct {
	fields types.MismatchedFieldsParams
}
```

and there's no setter method for it,
there's no way to override the `fields`.

This change makes the constructor public to make it possible to re-use the type (mostly in tests).

### Tests
- all unit tests pass