### PR TITLE
Makes batch.Processor return ErrBatchError when batch request fails and messages cannot be retried individually

### DIFF
--- a/batch/batch_errors.go
+++ b/batch/batch_errors.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	ErrStrBatchError                 = "Batch error"
 	ErrStrDisallowedEventName        = "Disallowed Event Name"
 	ErrStrConflictEmails             = "Email conflicts"
 	ErrStrConflictUserIds            = "UserId conflicts"
@@ -32,6 +33,7 @@ const (
 
 var (
 	ErrApiError                   = &iterable_errors.ApiError{}
+	ErrBatchError                 = errors.New(ErrStrBatchError)
 	ErrInvalidListId              = errors.New(ErrStrInvalidListId)
 	ErrConflictEmails             = errors.New(ErrStrConflictEmails)
 	ErrConflictUserIds            = errors.New(ErrStrConflictUserIds)


### PR DESCRIPTION
### Notes

When `batch.Processor` gets response from `ProcessBatch()`, `batch.Processor` checks the response status and if some messages need to be retried individually, the processor will attempt to retry those.

However, if `config.sendIndividual` is set to `false` or if response status makes it impossible to retry - we want to signal the caller that the message has a "Batch" error. In this case the caller can decide what to do with the message.

### Tests
- new unit tests