### PR TITLE
types: add ProfileUpdatedAt field to User struct

### DIFF
--- a/api/users_test.go
+++ b/api/users_test.go
@@ -406,6 +406,29 @@ func TestUsers_GetById(t *testing.T) {
 			expectFound: true,
 		},
 		{
+			name:   "user found with profileUpdatedAt",
+			userId: "789",
+			resBody: []byte(`{
+				"user": {
+					"email": "test@example.com",
+					"userId": "789",
+					"dataFields": {"firstName": "Test"},
+					"profileUpdatedAt": "2026-07-13T10:00:00Z"
+				}
+			}`),
+			resCode:   200,
+			expectUrl: "https://api.iterable.com/api/users/byUserId?userId=789",
+			expectRes: &types.User{
+				Email:  "test@example.com",
+				UserId: "789",
+				DataFields: map[string]interface{}{
+					"firstName": "Test",
+				},
+				ProfileUpdatedAt: "2026-07-13T10:00:00Z",
+			},
+			expectFound: true,
+		},
+		{
 			name:        "user not found",
 			userId:      "456",
 			resBody:     []byte(`{"code": "error.users.noUserWithIdExists", "msg": "User not found"}`),

--- a/types/users.go
+++ b/types/users.go
@@ -1,9 +1,10 @@
 package types
 
 type User struct {
-	Email      string                 `json:"email"`
-	UserId     string                 `json:"userId"`
-	DataFields map[string]interface{} `json:"dataFields"`
+	Email            string                 `json:"email"`
+	UserId           string                 `json:"userId"`
+	DataFields       map[string]interface{} `json:"dataFields"`
+	ProfileUpdatedAt string                 `json:"profileUpdatedAt,omitempty"`
 }
 
 type UserSentMessage struct {


### PR DESCRIPTION
Iterable's `GET /api/users/byUserId` response includes a `profileUpdatedAt`
field (ISO 8601 timestamp) indicating when the user profile was last
modified. This field was previously dropped during unmarshalling.

Adding it to the `User` struct allows consumers to check profile freshness
without needing to write custom traits or make raw HTTP calls.

Use case: `cdp-controlplane`'s PAE Identify canary workflow reads back
the user profile to verify the delivery pipeline is healthy by checking
that `profileUpdatedAt` is recent.