### PR TITLE
Fix batch processor race test

### DIFF
--- a/batch/processor_test.go
+++ b/batch/processor_test.go
@@ -1342,17 +1342,19 @@ func TestBatchProcessor_Stop_Add_race(t *testing.T) {
 	for i := range msgCnt {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			p.Add(Message{
 				Data: strconv.Itoa(i),
 			})
-			wg.Done()
 		}()
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			p.Stop()
 			p.Start()
 		}()
 	}
+	wg.Wait()
 
 	// last Stop() guarantees all messages are delivered
 	p.Stop()


### PR DESCRIPTION
## Why
`TestBatchProcessor_Stop_Add_race` can close the response channel before all spawned Stop/Start goroutines finish, allowing later sends to panic.

## What
- Wait for all spawned Add and Stop/Start goroutines before the final Stop
- Use defer when marking goroutines done so future failures do not leave the wait group hanging

## Risk Assessment
Low — test-only change that narrows synchronization in a flaky unit test.

Generated with Codex