### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
## Why
GitHub Actions is warning that Node.js 20 actions are deprecated and being forced onto the Node.js 24 runtime.

## What
- Update checkout and setup-go to their Node.js 24-compatible v7 majors
- Read the Go toolchain version from go.mod instead of hardcoding 1.24 in CI

## Risk Assessment
Low — CI-only maintenance change that keeps the existing build and test steps unchanged.

Generated with Codex